### PR TITLE
Storage

### DIFF
--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, Dispatch, useReducer } from 'react'
 import { Action } from './constants'
-import { setItem, getItem } from "./chrome/utils/storage";
+import { setSyncItem, getSyncItem, getLocalItem } from "./chrome/utils/storage";
 import { Storage } from "./constants"
 import { HistoryActions, historyReducer, draftReducer, settingsReducer, DraftActions, SettingsActions } from './reducers';
 
@@ -32,7 +32,7 @@ export type HistoryType = {
 }
 
 function getSettingsValuesFromStorage() {
-    getItem(null, (data) => {
+    getSyncItem(null, (data) => {
         return {
         api_key: data[Storage.API_KEY],
         enc_mode: data[Storage.ENC_MODE],
@@ -49,7 +49,7 @@ function getSettingsValuesFromStorage() {
 }
 
 function getHistoryValuesFromStorage() {
-    getItem(Storage.HISTORY, (data) => {
+    getLocalItem(Storage.HISTORY, (data) => {
         return data[Storage.HISTORY] as HistoryType[]
     })
     return [] as HistoryType[]

--- a/src/chrome/background.ts
+++ b/src/chrome/background.ts
@@ -1,7 +1,7 @@
 import { copyTextClipboard } from "../chrome/utils";
 import { encrypt, decrypt } from "../chrome/utils/crypto";
 import {postPastebin, getPastebin} from "../chrome/utils/pastebin";
-import { getItemAsync, addItem, setItem } from "../chrome/utils/storage";
+import { getSyncItemAsync, addLocalItem, setSyncItem } from "../chrome/utils/storage";
 import { Storage } from '../constants'
 
 /** Fired when the extension is first installed,
@@ -9,22 +9,22 @@ import { Storage } from '../constants'
  *  and when Chrome is updated to a new version. */
 chrome.runtime.onInstalled.addListener(async (details) => {
     console.log('onInstall, checking for settings, else set defaults', details);
-    let mode = await getItemAsync(Storage.ENC_MODE) as string
+    let mode = await getSyncItemAsync(Storage.ENC_MODE) as string
     if (mode === undefined) {
         console.log("Mode = ", "AES-CBC");
-        setItem(Storage.ENC_MODE, "AES-CBC")
+        setSyncItem(Storage.ENC_MODE, "AES-CBC")
     }
 
-    let len = await getItemAsync(Storage.KEY_LENGTH) as number
+    let len = await getSyncItemAsync(Storage.KEY_LENGTH) as number
     if (len === undefined) {
         console.log("Key_Len = ", 128);
-        setItem(Storage.KEY_LENGTH, 16)
+        setSyncItem(Storage.KEY_LENGTH, 16)
     }
 
-    let theme = await getItemAsync(Storage.THEME) as number
+    let theme = await getSyncItemAsync(Storage.THEME) as number
     if (theme === undefined) {
         console.log("Theme = ", "Light");
-        setItem(Storage.THEME, false)
+        setSyncItem(Storage.THEME, false)
     }
     //console.log(mode, len, theme);
 });
@@ -102,15 +102,15 @@ chrome.contextMenus.onClicked.addListener( async (clickData) => {
             key_length: "state.settings.key_length",
             date: Date(),
         }
-        addItem(Storage.HISTORY, history)
+        addLocalItem(Storage.HISTORY, history)
 
         alert("Key: " + res.key + "\nLink:" + link);
         copyTextClipboard("Key: " + res.key + "\nLink:" + link);
     }
     else if(clickData.menuItemId === "clipboardMenuItem"){
         let res = await encrypt(text)
-        let mode = await getItemAsync(Storage.ENC_MODE) as string
-        let len = await getItemAsync(Storage.KEY_LENGTH) as number
+        let mode = await getSyncItemAsync(Storage.ENC_MODE) as string
+        let len = await getSyncItemAsync(Storage.KEY_LENGTH) as number
         console.log("ENC text", res.data)
 
         const history = {
@@ -123,7 +123,7 @@ chrome.contextMenus.onClicked.addListener( async (clickData) => {
         }
 
         console.log("ENC text", history)
-        addItem(Storage.HISTORY, history)
+        addLocalItem(Storage.HISTORY, history)
 
         alert("Key: " + res.key + "\nCiphertext:" + res.data);
         copyTextClipboard("Key: " + res.key + "\nCiphertext:" + res.data);

--- a/src/chrome/utils/crypto.ts
+++ b/src/chrome/utils/crypto.ts
@@ -1,10 +1,10 @@
 import forge from 'node-forge';
-import { getItemAsync } from "./storage";
+import { getSyncItemAsync } from "./storage";
 import { Storage } from "../../constants"
 
 export async function encrypt(data: string){
-    let mode = await getItemAsync(Storage.ENC_MODE) as string
-    let len = await getItemAsync(Storage.KEY_LENGTH) as number
+    let mode = await getSyncItemAsync(Storage.ENC_MODE) as string
+    let len = await getSyncItemAsync(Storage.KEY_LENGTH) as number
 
     // encrypt data
     const encRes = encryptText(data, mode, len)

--- a/src/chrome/utils/pastebin.ts
+++ b/src/chrome/utils/pastebin.ts
@@ -1,4 +1,4 @@
-import { getItemAsync } from "./storage";
+import { getSyncItemAsync } from "./storage";
 import { Storage, API_ERROR } from "../../constants";
 
 
@@ -10,7 +10,7 @@ export async function postPastebin(encryptQuery: string) {
         "_csrf-frontend=329554c223d6a49136d2267538fc128591f3ec2150a223caa1d6db2d96f0265aa%3A2%3A%7Bi%3A0%3Bs%3A14%3A%22_csrf-frontend%22%3Bi%3A1%3Bs%3A32%3A%22rO1MDUiUJzJoMpRxGyEtQ9KVFoodbesw%22%3B%7D; pastebin_posted=99663e9444444257d4931e06307949fe5a481efea6e1d02e1d14d0dd216f60dca%3A2%3A%7Bi%3A0%3Bs%3A15%3A%22pastebin_posted%22%3Bi%3A1%3Bs%3A8%3A%22JC4FD0vP%22%3B%7D"
     );
 
-    const apiKey = await getItemAsync(Storage.API_KEY) as string;
+    const apiKey = await getSyncItemAsync(Storage.API_KEY) as string;
     console.log("API ", apiKey);
     if (apiKey === undefined) {
         alert("Please set your Pastbin API key");
@@ -51,7 +51,7 @@ export async function getPastebin(link: string) {
         link = array[0];
     }
 
-    const response = await fetch(`https://pastebin.com/raw/` + link);
+    const response = await fetch(`https://cors.securebin.workers.dev/?https://pastebin.com/raw/` + link);
 
     if (!response.ok) {
         const error = await response.text();

--- a/src/chrome/utils/storage.ts
+++ b/src/chrome/utils/storage.ts
@@ -1,51 +1,18 @@
-
-export const setItem = (key: string, value: any, callback?: () => void) => {
+/////////////////////////  SYNC STORAGE //////////////////////////////
+// Chrome sync storage limit of 8,192 bytes per item, 102,400 Bytes total storage 
+export const setSyncItem = (key: string, value: any, callback?: () => void) => {
     chrome.storage.sync.set({ [key]: value }, callback)
 }
 
-export const getItem = (key: string | string[] | null, callback: (items: { [key: string]: any; }) => void) => {
+export const getSyncItem = (key: string | string[] | null, callback: (items: { [key: string]: any; }) => void) => {
     return chrome.storage.sync.get(key, callback)
 }
 
-export const getItemAtIndex = (key: string, index: number, callback: (items: { [key: string]: any; }) => void) => {
-    getItem(key, (data) => {
-        const result = data[key];
-        if (result && result.length > index) {
-            return result[index]
-        }
-    })
+export const deleteSyncItem  = (key: string | string[], callback?: () => void) => {
+    return chrome.storage.sync.remove(key, callback)
 }
 
-export const addItem = (key: string, value: any, callback?: () => void) => {
-    getItem(key, (data) => {
-        //console.log("DATA FROM ADD", data);
-        let result = data[key];
-        if(!result) {
-            result = [];
-        }
-        result.push(value);
-        //console.log("ADDING ITEM", value)
-        //console.log("RESULTING VALUE", result)
-        setItem(key, result)
-    })
-}
-
-export const removeItem = (key: string, value: any, index: number, callback?: () => void) => {
-    getItem(key, (data) => {
-        let result = data[key];
-        if(result && result.length > index) {
-            result.splice(index, 1);
-        }
-        return chrome.storage.sync.set({ [key]: result }, callback)
-    })
-}
-
-export const clearItems = (key: string, value: any, callback?: () => void) => {
-    return chrome.storage.sync.set({ [key]: [] }, callback)
-}
-
-
-export const getItemAsync = async (key: string) => {
+export const getSyncItemAsync = async (key: string) => {
     return new Promise((resolve, reject) => {
       chrome.storage.sync.get([key], function (result) {
         if (result[key] === undefined) {
@@ -58,6 +25,54 @@ export const getItemAsync = async (key: string) => {
     });
   };
 
-export const deleteItem = (key: string | string[], callback?: () => void) => {
-    return chrome.storage.sync.remove(key, callback)
+
+/////////////////////////  LOCAL STORAGE //////////////////////////////
+// Chrome limit 5,242,880  Bytes total storage, can be set to unlimited
+export const setLocalItem = (key: string, value: any, callback?: () => void) => {
+    chrome.storage.local.set({ [key]: value }, callback)
+}
+
+export const getLocalItem = (key: string | string[] | null, callback: (items: { [key: string]: any; }) => void) => {
+    return chrome.storage.local.get(key, callback)
+}
+
+export const deleteLocalItem   = (key: string | string[], callback?: () => void) => {
+    return chrome.storage.local.remove(key, callback)
+}
+
+export const addLocalItem = (key: string, value: any, callback?: () => void) => {
+    getLocalItem(key, (data) => {
+        //console.log("DATA FROM ADD", data);
+        let result = data[key];
+        if(!result) {
+            result = [];
+        }
+        result.push(value);
+        //console.log("ADDING ITEM", value)
+        //console.log("RESULTING VALUE", result)
+        setLocalItem(key, result)
+    })
+}
+
+export const getItemAtIndex = (key: string, index: number, callback: (items: { [key: string]: any; }) => void) => {
+    getLocalItem(key, (data) => {
+        const result = data[key];
+        if (result && result.length > index) {
+            return result[index]
+        }
+    })
+}
+
+export const removeItem = (key: string, value: any, index: number, callback?: () => void) => {
+    getLocalItem(key, (data) => {
+        let result = data[key];
+        if(result && result.length > index) {
+            result.splice(index, 1);
+        }
+        return chrome.storage.local.set({ [key]: result }, callback)
+    })
+}
+
+export const clearItems = (key: string, value: any, callback?: () => void) => {
+    return chrome.storage.local.set({ [key]: [] }, callback)
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,4 +62,8 @@ export const KEY_LENGTHS = [
     }
 ];
 
-export const MAX_TEXT_LENGTH = 512
+// Limiting factors:
+// Pastebine 10MB but auto removes text pastes greater then 1000 characters/bytes
+// cipher text is ~1.5 times larger than plaintext so limit is half of max
+export const MAX_PASTEBIN_TEXT_LENGTH = 512
+export const MAX_ENC_TEXT_LENGTH = 4096

--- a/src/hooks/usePasteBinPost.js
+++ b/src/hooks/usePasteBinPost.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { getItemAsync, getItem } from "../chrome/utils/storage";
+import { getSyncItemAsync, getSyncItem } from "../chrome/utils/storage";
 import { Storage } from "../constants";
 
 function usePasteBinPost(encryptQuery) {
@@ -15,7 +15,7 @@ function usePasteBinPost(encryptQuery) {
         let ignore = false;
         const controller = new AbortController();
         async function fetchSearchResults() {
-            const apiKey = await getItemAsync(Storage.API_KEY)
+            const apiKey = await getSyncItemAsync(Storage.API_KEY)
             console.log("API key from storage: ", apiKey)
 
             var urlencoded = new URLSearchParams();

--- a/src/reducers.tsx
+++ b/src/reducers.tsx
@@ -1,5 +1,5 @@
 import {DraftType, HistoryType, SettingsType } from "./AppContext";
-import { setItem, getItem } from "./chrome/utils/storage";
+import { setSyncItem, getSyncItem } from "./chrome/utils/storage";
 import { Storage, Action, DEFAULT_CONTEXT } from "./constants"
 
 type ActionMap<M extends { [index: string]: any }> = {

--- a/src/routes/Dialog.tsx
+++ b/src/routes/Dialog.tsx
@@ -6,7 +6,7 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
-import {setItem, getItem} from "../chrome/utils/storage";
+import {setSyncItem, getSyncItem} from "../chrome/utils/storage";
 import { Storage } from "../constants";
 import {Card, Divider, InputBase, Typography } from '@mui/material';
 import { makeStyles, createStyles } from '@mui/styles';
@@ -41,9 +41,9 @@ export default function FormDialog(props: any) {
     const handleClose = () => {
 
         console.log("Setting the API KEY:",apiKey);
-        setItem(Storage.API_KEY,apiKey);
+        setSyncItem(Storage.API_KEY,apiKey);
         setOpen(false);
-        getItem(Storage.API_KEY, (data) => {
+        getSyncItem(Storage.API_KEY, (data) => {
             //console.log(KEY_LENGTH)
           })
     };

--- a/src/routes/History.tsx
+++ b/src/routes/History.tsx
@@ -5,7 +5,7 @@ import ListItemText from '@mui/material/ListItemText';
 import {Card, IconButton, Typography } from '@mui/material';
 import { makeStyles } from '@mui/styles';
 import LockOpenIcon from '@mui/icons-material/LockOpen';
-import { getItem } from '../chrome/utils/storage';
+import { getLocalItem, getSyncItem } from '../chrome/utils/storage';
 import { Storage } from '../constants'
 
 const useStyles = makeStyles(theme => ({
@@ -30,9 +30,8 @@ const useStyles = makeStyles(theme => ({
 
 export default function History() {
     useEffect(() => {
-        // setItem(Storage.HISTORY, historyItems);
 
-        getItem(Storage.HISTORY, (data) => {
+        getLocalItem(Storage.HISTORY, (data) => {
             console.log("HISTORY", data[Storage.HISTORY]);
             setHistory(data[Storage.HISTORY]);
         })

--- a/src/routes/Result.tsx
+++ b/src/routes/Result.tsx
@@ -5,7 +5,7 @@ import ContentPasteIcon from '@mui/icons-material/ContentPaste';
 import ErrorIcon from '@mui/icons-material/Error';
 import { makeStyles, createStyles } from '@mui/styles';
 import { AppContext, HistoryType } from "../AppContext";
-import { getItem } from '../chrome/utils/storage';
+import { getLocalItem, getSyncItem } from '../chrome/utils/storage';
 import { Storage } from '../constants'
 import clsx from "clsx";
 import { copyTextClipboard } from "../chrome/utils"
@@ -80,7 +80,7 @@ export type LHistoryType = {
 export default function Result(props: any) {
 
     useEffect(() => {
-        getItem(Storage.HISTORY, (data) => {
+        getLocalItem(Storage.HISTORY, (data) => {
             console.log("HISTORY from there", data[Storage.HISTORY]);
             setHistory(data[Storage.HISTORY]);
         })

--- a/src/routes/Settings.tsx
+++ b/src/routes/Settings.tsx
@@ -6,7 +6,7 @@ import {
 import { ChevronRight } from "@mui/icons-material";
 // import { ConfigContext } from "../ConfigContext";
 import { makeStyles, createStyles } from '@mui/styles';
-import { setItem, getItem } from "../chrome/utils/storage";
+import { setSyncItem, getSyncItem, setLocalItem } from "../chrome/utils/storage";
 import { Storage, ENCRYPTION_METHODS, KEY_LENGTHS, DEFAULT_CONTEXT } from "../constants";
 import FormDialog from "./Dialog"
 
@@ -52,48 +52,48 @@ export const Settings = () => {
 
   // Note: a key size of 16 bytes will use AES-128, 24 => AES-192, 32 => AES-256
   function getSettings(): any {
-    getItem(Storage.API_KEY, (data) => {
+    getSyncItem(Storage.API_KEY, (data) => {
       setApiKey(data[Storage.API_KEY]);
       //console.log(APIKEY)
     })
 
-    getItem(Storage.ENC_MODE, (data) => {
+    getSyncItem(Storage.ENC_MODE, (data) => {
       setEncMode(data[Storage.ENC_MODE]);
       //console.log(ENC_MODE)
     })
 
-    getItem(Storage.THEME, (data) => {
+    getSyncItem(Storage.THEME, (data) => {
       setTheme(data[Storage.THEME]);
       //console.log("Getting theme", data[Storage.THEME])
     })
 
-    getItem(Storage.KEY_LENGTH, (data) => {
+    getSyncItem(Storage.KEY_LENGTH, (data) => {
       setKeyLength(data[Storage.KEY_LENGTH]);
       //console.log(KEY_LENGTH)
     })
   }
 
   const keyLengthHandler = (e: any) => {
-    setItem(Storage.KEY_LENGTH, e.target.value)
+    setSyncItem(Storage.KEY_LENGTH, e.target.value)
     setKeyLength(e.target.value);
     //console.log(KEY_LENGTH)
 
-    getItem(Storage.KEY_LENGTH, (data) => {
+    getSyncItem(Storage.KEY_LENGTH, (data) => {
       //console.log(KEY_LENGTH)
     })
   }
 
   const encModeHandler = (e: any) => {
-    setItem(Storage.ENC_MODE, e.target.value);
+    setSyncItem(Storage.ENC_MODE, e.target.value);
     setEncMode(e.target.value);
   }
 
   const clearHistory = (e: any) => {
-    setItem(Storage.HISTORY, []);
+    setLocalItem(Storage.HISTORY, []);
   }
 
   const themeHandler = (e: any) => {
-    setItem(Storage.THEME, !THEME);
+    setSyncItem(Storage.THEME, !THEME);
     setTheme(!THEME);
     //TODO do darkmode magic here
   }
@@ -101,10 +101,10 @@ export const Settings = () => {
   const resetSettings = (e: any) => {
     const d = DEFAULT_CONTEXT;
 
-    setItem(Storage.THEME, d.theme);
-    setItem(Storage.API_KEY, d.api_key);
-    setItem(Storage.ENC_MODE, d.enc_mode);
-    setItem(Storage.KEY_LENGTH, d.key_length);
+    setSyncItem(Storage.THEME, d.theme);
+    setSyncItem(Storage.API_KEY, d.api_key);
+    setSyncItem(Storage.ENC_MODE, d.enc_mode);
+    setSyncItem(Storage.KEY_LENGTH, d.key_length);
 
     setEncMode(d.enc_mode);
     setKeyLength(String(d.key_length));


### PR DESCRIPTION
Update Text limit to:
* 512 for pastebin enc (Pastebin 1000 char limit)
* 4096 for everything else (Chrome storage 8192 byte limit)

^ Cipher text is ~1.5x plain text

Also migrate history to Local storage to avoid filling up storage limit, while keeping settings in sync storage so they will stay linked to google account.