### PR TITLE
Lowercase branding, remove CORS proxy, minimal permissions, 2.0.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SecureBin</title>
+    <title>securebin</title>
   </head>
   <body>
     <div id="root"></div>

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-  "name": "SecureBin: Powerful Pastebin Tool",
+  "name": "securebin: Powerful Pastebin Tool",
   "description": "Securely encrypt your text on Pastebin.com",
   "version": "2.0.1",
   "manifest_version": 3,
   "action": {
-    "default_title": "Open SecureBin"
+    "default_title": "Open securebin"
   },
   "icons": {
     "16": "icons/logo48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -21,20 +21,10 @@
     "clipboardWrite",
     "clipboardRead",
     "activeTab",
-    "tabs"
-  ],
-  "optional_host_permissions": [
-    "<all_urls>"
+    "scripting"
   ],
   "host_permissions": [
     "https://pastebin.com/*"
-  ],
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["src/content/index.tsx"],
-      "run_at": "document_idle"
-    }
   ],
   "web_accessible_resources": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "securebin: Powerful Pastebin Tool",
   "description": "Securely encrypt your text on Pastebin.com",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "manifest_version": 3,
   "action": {
     "default_title": "Open securebin"
@@ -27,8 +27,7 @@
     "<all_urls>"
   ],
   "host_permissions": [
-    "https://pastebin.com/*",
-    "https://cors.securebin.workers.dev/*"
+    "https://pastebin.com/*"
   ],
   "content_scripts": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "securebin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "type": "module",
   "scripts": {
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "lint": "eslint . --fix",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:relay": "node scripts/verify-relay.mjs"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",
@@ -48,6 +49,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.20",
+    "puppeteer-core": "^25.3.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",

--- a/scripts/verify-relay.mjs
+++ b/scripts/verify-relay.mjs
@@ -1,0 +1,169 @@
+/**
+ * Live verification of the SB_FETCH background relay — the path the injected
+ * in-page panel uses for all Pastebin traffic (content scripts can't fetch
+ * cross-origin themselves; see pbFetch in src/lib/pastebin.ts).
+ *
+ * Loads the built extension (dist/) into Chrome for Testing, then:
+ *   1. direct fetch from an extension page  → CORS-exempt via host_permissions
+ *   2. SB_FETCH GET from a real content-script world on a live page
+ *   3. SB_FETCH POST round-trip to the Pastebin API from that world
+ *      (with PASTEBIN_API_KEY set: posts a real paste and fetches it back;
+ *       without: expects Pastebin's "invalid api_dev_key" error, which still
+ *       proves the relay reached the API and returned its response)
+ *   4. SB_FETCH to a non-Pastebin URL → must be blocked
+ *
+ * Requires:
+ *   npm run build                                  (dist/ must exist)
+ *   CHROME_PATH=<path to Chrome for Testing binary>
+ *     (branded Chrome ≥137 ignores --load-extension; install one with
+ *      npx @puppeteer/browsers install chrome@stable)
+ * Run:
+ *   npm run test:relay
+ */
+import puppeteer from 'puppeteer-core'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import fs from 'node:fs'
+
+const DIST = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist')
+const CHROME = process.env.CHROME_PATH
+const API_KEY = process.env.PASTEBIN_API_KEY ?? ''
+
+if (!CHROME || !fs.existsSync(CHROME)) {
+  console.error('Set CHROME_PATH to a Chrome for Testing binary (npx @puppeteer/browsers install chrome@stable)')
+  process.exit(1)
+}
+if (!fs.existsSync(path.join(DIST, 'manifest.json'))) {
+  console.error(`No build at ${DIST} — run \`npm run build\` first`)
+  process.exit(1)
+}
+
+let failures = 0
+function check(name, ok, detail = '') {
+  console.log(`${ok ? '✅' : '❌'} ${name}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures++
+}
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME,
+  headless: true,
+  args: [
+    `--disable-extensions-except=${DIST}`,
+    `--load-extension=${DIST}`,
+    '--no-first-run',
+  ],
+})
+
+try {
+  // ── Extension service worker must come up ─────────────────────────────────
+  const swTarget = await browser.waitForTarget(
+    t => t.type() === 'service_worker' && t.url().startsWith('chrome-extension://'),
+    { timeout: 20_000 },
+  )
+  const extId = new URL(swTarget.url()).host
+  check('service worker running', true, extId)
+
+  // ── 1. Direct fetch from an extension page (popup path) ──────────────────
+  const popup = await browser.newPage()
+  await popup.goto(`chrome-extension://${extId}/index.html`, { waitUntil: 'domcontentloaded' })
+  const direct = await popup.evaluate(async () => {
+    const body = new URLSearchParams({ api_dev_key: 'relay-verify-dummy', api_option: 'userdetails' })
+    const r = await fetch('https://pastebin.com/api/api_post.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    })
+    return { status: r.status, text: (await r.text()).slice(0, 100) }
+  })
+  check(
+    'extension page fetches pastebin.com directly (no CORS error)',
+    direct.text.includes('invalid api_dev_key'),
+    `HTTP ${direct.status}: ${direct.text}`,
+  )
+
+  // ── Find the extension's content-script world on a real page ─────────────
+  const page = await browser.newPage()
+  const cdp = await page.createCDPSession()
+  const contexts = []
+  cdp.on('Runtime.executionContextCreated', e => contexts.push(e.context))
+  await cdp.send('Runtime.enable')
+  await page.goto('https://example.com', { waitUntil: 'networkidle2' })
+
+  // The panel's world is the isolated context where content/index.tsx set the flag
+  let csContext = null
+  for (let attempt = 0; attempt < 20 && !csContext; attempt++) {
+    for (const ctx of contexts.filter(c => !c.auxData?.isDefault)) {
+      try {
+        const { result } = await cdp.send('Runtime.evaluate', {
+          expression: 'window.__SECUREBIN_INJECTED__ === true',
+          contextId: ctx.id,
+          returnByValue: true,
+        })
+        if (result.value === true) { csContext = ctx; break }
+      } catch { /* context gone — keep looking */ }
+    }
+    if (!csContext) await new Promise(r => setTimeout(r, 250))
+  }
+  check('content script injected on a live page', !!csContext)
+  if (!csContext) throw new Error('content-script world not found')
+
+  const relay = async (msg) => {
+    const { result, exceptionDetails } = await cdp.send('Runtime.evaluate', {
+      expression: `chrome.runtime.sendMessage(${JSON.stringify(msg)})`,
+      contextId: csContext.id,
+      awaitPromise: true,
+      returnByValue: true,
+    })
+    if (exceptionDetails) throw new Error(exceptionDetails.exception?.description ?? 'evaluate failed')
+    return result.value
+  }
+
+  // ── 2. Relay GET from the content-script world ────────────────────────────
+  const got = await relay({ type: 'SB_FETCH', url: 'https://pastebin.com/robots.txt' })
+  check(
+    'relay GET returns a pastebin.com response',
+    got && typeof got.status === 'number' && got.status !== 0 && typeof got.text === 'string',
+    got ? `HTTP ${got.status}, ${got.text.length} bytes` : 'no response',
+  )
+
+  // ── 3. Relay POST round-trip to the Pastebin API ──────────────────────────
+  if (API_KEY) {
+    const marker = `securebin relay verification — ${new Date().toISOString()}`
+    const postBody = new URLSearchParams({
+      api_dev_key: API_KEY, api_paste_code: marker, api_option: 'paste', api_paste_private: '1',
+    }).toString()
+    const posted = await relay({ type: 'SB_FETCH', url: 'https://pastebin.com/api/api_post.php', body: postBody })
+    const postedUrl = posted?.text?.trim() ?? ''
+    check('relay POST posts a real paste', /^https:\/\/pastebin\.com\//.test(postedUrl), postedUrl || posted?.text?.slice(0, 80))
+
+    if (/^https:\/\/pastebin\.com\//.test(postedUrl)) {
+      const key = postedUrl.split('/').pop()
+      const fetched = await relay({ type: 'SB_FETCH', url: `https://pastebin.com/raw/${key}` })
+      check('relay GET fetches the paste back verbatim', fetched?.text?.trim() === marker, `HTTP ${fetched?.status}`)
+    }
+  } else {
+    const posted = await relay({
+      type: 'SB_FETCH',
+      url: 'https://pastebin.com/api/api_post.php',
+      body: new URLSearchParams({ api_dev_key: 'relay-verify-dummy', api_option: 'userdetails' }).toString(),
+    })
+    check(
+      'relay POST reaches the Pastebin API (no key set — expecting its error reply)',
+      posted?.text?.includes('invalid api_dev_key'),
+      `HTTP ${posted?.status}: ${posted?.text?.slice(0, 80)}`,
+    )
+  }
+
+  // ── 4. Non-Pastebin URLs must be refused ──────────────────────────────────
+  const blocked = await relay({ type: 'SB_FETCH', url: 'https://example.com/' })
+  check(
+    'relay blocks non-Pastebin URLs',
+    blocked?.ok === false && blocked?.status === 0 && /Blocked/.test(blocked?.text ?? ''),
+    blocked?.text,
+  )
+} finally {
+  await browser.close()
+}
+
+console.log(failures === 0 ? '\nAll relay checks passed.' : `\n${failures} check(s) FAILED`)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify-relay.mjs
+++ b/scripts/verify-relay.mjs
@@ -1,16 +1,21 @@
 /**
- * Live verification of the SB_FETCH background relay — the path the injected
- * in-page panel uses for all Pastebin traffic (content scripts can't fetch
- * cross-origin themselves; see pbFetch in src/lib/pastebin.ts).
+ * Live verification of the on-demand panel injection + SB_FETCH background
+ * relay — the path the injected in-page panel uses for all Pastebin traffic
+ * (content scripts can't fetch cross-origin themselves; see pbFetch in
+ * src/lib/pastebin.ts).
  *
  * Loads the built extension (dist/) into Chrome for Testing, then:
  *   1. direct fetch from an extension page  → CORS-exempt via host_permissions
- *   2. SB_FETCH GET from a real content-script world on a live page
- *   3. SB_FETCH POST round-trip to the Pastebin API from that world
+ *   2. panel injection via chrome.scripting.executeScript from the service
+ *      worker into a pastebin.com tab (host permission; in real use activeTab
+ *      grants the same on whatever tab the user clicks) — and confirms
+ *      injection FAILS on a non-permitted site, proving the minimal footprint
+ *   3. SB_FETCH GET from the real content-script world
+ *   4. SB_FETCH POST round-trip to the Pastebin API from that world
  *      (with PASTEBIN_API_KEY set: posts a real paste and fetches it back;
  *       without: expects Pastebin's "invalid api_dev_key" error, which still
  *       proves the relay reached the API and returned its response)
- *   4. SB_FETCH to a non-Pastebin URL → must be blocked
+ *   5. SB_FETCH to a non-Pastebin URL → must be blocked
  *
  * Requires:
  *   npm run build                                  (dist/ must exist)
@@ -38,6 +43,14 @@ if (!fs.existsSync(path.join(DIST, 'manifest.json'))) {
   process.exit(1)
 }
 
+// The crxjs ?script loader the service worker injects on demand
+const loaderFile = fs.readdirSync(path.join(DIST, 'assets')).find(f => f.includes('-loader-'))
+if (!loaderFile) {
+  console.error('No content-script loader found in dist/assets — did the build change?')
+  process.exit(1)
+}
+const LOADER = `assets/${loaderFile}`
+
 let failures = 0
 function check(name, ok, detail = '') {
   console.log(`${ok ? '✅' : '❌'} ${name}${detail ? ` — ${detail}` : ''}`)
@@ -62,6 +75,7 @@ try {
   )
   const extId = new URL(swTarget.url()).host
   check('service worker running', true, extId)
+  const sw = await swTarget.worker()
 
   // ── 1. Direct fetch from an extension page (popup path) ──────────────────
   const popup = await browser.newPage()
@@ -81,17 +95,47 @@ try {
     `HTTP ${direct.status}: ${direct.text}`,
   )
 
-  // ── Find the extension's content-script world on a real page ─────────────
+  // ── 2. On-demand injection from the service worker ───────────────────────
+  // One permitted tab (pastebin.com — covered by host_permissions, like an
+  // activeTab grant in real use) and one non-permitted tab (example.com).
   const page = await browser.newPage()
   const cdp = await page.createCDPSession()
   const contexts = []
   cdp.on('Runtime.executionContextCreated', e => contexts.push(e.context))
   await cdp.send('Runtime.enable')
-  await page.goto('https://example.com', { waitUntil: 'networkidle2' })
+  await page.goto('https://pastebin.com/robots.txt', { waitUntil: 'networkidle2' })
 
-  // The panel's world is the isolated context where content/index.tsx set the flag
+  const other = await browser.newPage()
+  await other.goto('https://example.com', { waitUntil: 'networkidle2' })
+
+  const injection = await sw.evaluate(async (loader) => {
+    const tabs = await chrome.tabs.query({})
+    const injected = []
+    const blocked = []
+    for (const t of tabs) {
+      try {
+        await chrome.scripting.executeScript({ target: { tabId: t.id }, files: [loader] })
+        injected.push(t.id)
+      } catch (e) {
+        blocked.push(String(e?.message ?? e).slice(0, 60))
+      }
+    }
+    return { injected, blocked, total: tabs.length }
+  }, LOADER)
+  check(
+    'panel injects into the permitted tab only',
+    injection.injected.length === 1,
+    `injected into ${injection.injected.length} of ${injection.total} tabs`,
+  )
+  check(
+    'injection is refused on non-permitted sites (no <all_urls> anymore)',
+    injection.blocked.some(m => /permission|cannot|access/i.test(m)),
+    injection.blocked[0] ?? 'no blocked tabs',
+  )
+
+  // ── Find the injected content-script world ────────────────────────────────
   let csContext = null
-  for (let attempt = 0; attempt < 20 && !csContext; attempt++) {
+  for (let attempt = 0; attempt < 40 && !csContext; attempt++) {
     for (const ctx of contexts.filter(c => !c.auxData?.isDefault)) {
       try {
         const { result } = await cdp.send('Runtime.evaluate', {
@@ -104,7 +148,7 @@ try {
     }
     if (!csContext) await new Promise(r => setTimeout(r, 250))
   }
-  check('content script injected on a live page', !!csContext)
+  check('content-script world live after injection', !!csContext)
   if (!csContext) throw new Error('content-script world not found')
 
   const relay = async (msg) => {
@@ -118,7 +162,7 @@ try {
     return result.value
   }
 
-  // ── 2. Relay GET from the content-script world ────────────────────────────
+  // ── 3. Relay GET from the content-script world ────────────────────────────
   const got = await relay({ type: 'SB_FETCH', url: 'https://pastebin.com/robots.txt' })
   check(
     'relay GET returns a pastebin.com response',
@@ -126,7 +170,7 @@ try {
     got ? `HTTP ${got.status}, ${got.text.length} bytes` : 'no response',
   )
 
-  // ── 3. Relay POST round-trip to the Pastebin API ──────────────────────────
+  // ── 4. Relay POST round-trip to the Pastebin API ──────────────────────────
   if (API_KEY) {
     const marker = `securebin relay verification — ${new Date().toISOString()}`
     const postBody = new URLSearchParams({
@@ -154,7 +198,7 @@ try {
     )
   }
 
-  // ── 4. Non-Pastebin URLs must be refused ──────────────────────────────────
+  // ── 5. Non-Pastebin URLs must be refused ──────────────────────────────────
   const blocked = await relay({ type: 'SB_FETCH', url: 'https://example.com/' })
   check(
     'relay blocks non-Pastebin URLs',

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,16 +1,52 @@
 import { StorageKey, EncryptionMode, DEFAULT_API_KEY, encodeStoredApiKey, decodeStoredApiKey } from './lib/constants'
+import contentScript from './content/index.tsx?script'
 
+// With activeTab (no "tabs" permission), tab.url is only readable in handlers
+// fired by a user gesture on that tab — and is undefined on pages activeTab
+// can't grant (chrome:// etc.), which is exactly the restricted set.
 const RESTRICTED = /^(chrome:|chrome-extension:|about:|edge:|brave:)/
 
 function isRestrictedUrl(url?: string) {
   return !url || RESTRICTED.test(url)
 }
 
-async function syncActionPopup(tabId: number, url?: string) {
-  await chrome.action.setPopup({
-    tabId,
-    popup: isRestrictedUrl(url) ? 'index.html' : '',
-  })
+// The panel is injected on demand (activeTab + scripting) rather than declared
+// as a <all_urls> content script. The crxjs loader finishes registering the
+// panel's message listener slightly after executeScript resolves, so post-
+// injection sends retry briefly.
+async function sendToTab(tabId: number, message: unknown) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await chrome.tabs.sendMessage(tabId, message)
+    } catch (e) {
+      if (attempt >= 20) throw e
+      await new Promise(r => setTimeout(r, 100))
+    }
+  }
+}
+
+/** Inject the panel into the tab if it isn't there yet. Throws where injection is impossible. */
+async function ensurePanel(tabId: number) {
+  try {
+    await chrome.tabs.sendMessage(tabId, { type: 'SB_PING' })
+    return
+  } catch {
+    await chrome.scripting.executeScript({ target: { tabId }, files: [contentScript] })
+  }
+}
+
+/** Panel unavailable on this page — show the popup instead. */
+async function openPopupFallback(tabId?: number) {
+  try {
+    if (tabId !== undefined) await chrome.action.setPopup({ tabId, popup: 'index.html' })
+    await chrome.action.openPopup()
+  } catch {
+  } finally {
+    // Reset so the next click re-evaluates instead of always opening the popup
+    if (tabId !== undefined) {
+      try { await chrome.action.setPopup({ tabId, popup: '' }) } catch {}
+    }
+  }
 }
 
 function registerContextMenus() {
@@ -40,17 +76,21 @@ chrome.runtime.onInstalled.addListener(async () => {
 
 chrome.runtime.onStartup.addListener(registerContextMenus)
 
-chrome.tabs.onActivated.addListener(async ({ tabId }) => {
-  const tab = await chrome.tabs.get(tabId)
-  await syncActionPopup(tabId, tab.url)
-})
-
-chrome.tabs.onUpdated.addListener(async (tabId, info, tab) => {
-  if (info.status === 'complete') await syncActionPopup(tabId, tab.url)
-})
-
-chrome.action.onClicked.addListener(tab => {
-  if (tab.id) chrome.tabs.sendMessage(tab.id, { type: 'SB_TOGGLE' })
+chrome.action.onClicked.addListener(async tab => {
+  if (!tab.id) return
+  // Panel already injected — just toggle it
+  try {
+    await chrome.tabs.sendMessage(tab.id, { type: 'SB_TOGGLE' })
+    return
+  } catch {}
+  if (!isRestrictedUrl(tab.url)) {
+    try {
+      await chrome.scripting.executeScript({ target: { tabId: tab.id }, files: [contentScript] })
+      await sendToTab(tab.id, { type: 'SB_OPEN' })
+      return
+    } catch {} // injection blocked (e.g. Chrome Web Store) — fall through
+  }
+  await openPopupFallback(tab.id)
 })
 
 // Fetch relay for the injected in-page panel. Content scripts are subject to
@@ -87,23 +127,29 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 
   if (info.menuItemId === 'securebinOpen') {
     if (tab?.id && !isRestrictedUrl(tab.url)) {
-      // Injected mode: pass text directly in the message — content scripts cannot
-      // read chrome.storage.session (MV3 restriction), so we avoid it entirely
-      chrome.tabs.sendMessage(tab.id, { type: 'SB_OPEN', pendingText: text })
-    } else {
-      // Popup mode: session storage IS available in extension pages
-      try { await chrome.storage.session.set({ pendingText: { text } }) } catch {}
-      try { await chrome.action.openPopup() } catch {}
+      try {
+        await ensurePanel(tab.id)
+        // Injected mode: pass text directly in the message — content scripts cannot
+        // read chrome.storage.session (MV3 restriction), so we avoid it entirely
+        await sendToTab(tab.id, { type: 'SB_OPEN', pendingText: text })
+        return
+      } catch {} // injection blocked — fall through to the popup
     }
+    // Popup mode: session storage IS available in extension pages
+    try { await chrome.storage.session.set({ pendingText: { text } }) } catch {}
+    await openPopupFallback(tab?.id)
     return
   }
 
   if (info.menuItemId === 'securebinPost') {
-    const isInjectable = tab?.id && !isRestrictedUrl(tab.url)
-
-    if (isInjectable) {
-      // Show the panel immediately with a loading state so the user sees feedback
-      chrome.tabs.sendMessage(tab.id!, { type: 'SB_OPEN', quickPostLoading: true })
+    let panelShown = false
+    if (tab?.id && !isRestrictedUrl(tab.url)) {
+      try {
+        await ensurePanel(tab.id)
+        // Show the panel immediately with a loading state so the user sees feedback
+        await sendToTab(tab.id, { type: 'SB_OPEN', quickPostLoading: true })
+        panelShown = true
+      } catch {} // injection blocked — deliver the result to the popup instead
     }
 
     let apiKey = DEFAULT_API_KEY
@@ -139,12 +185,12 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 
     const payload = { url, error, text, timestamp: Date.now() }
 
-    if (isInjectable) {
+    if (panelShown) {
       // Send result to the already-open panel
-      chrome.tabs.sendMessage(tab.id!, { type: 'SB_QUICK_POST_RESULT', payload })
+      chrome.tabs.sendMessage(tab!.id!, { type: 'SB_QUICK_POST_RESULT', payload })
     } else {
       try { await chrome.storage.session.set({ pendingQuickPost: payload }) } catch {}
-      try { await chrome.action.openPopup() } catch {}
+      await openPopupFallback(tab?.id)
     }
   }
 })

--- a/src/background.ts
+++ b/src/background.ts
@@ -15,7 +15,7 @@ async function syncActionPopup(tabId: number, url?: string) {
 
 function registerContextMenus() {
   chrome.contextMenus.removeAll(() => {
-    chrome.contextMenus.create({ id: 'securebinRoot', title: 'SecureBin', contexts: ['selection'] })
+    chrome.contextMenus.create({ id: 'securebinRoot', title: 'securebin', contexts: ['selection'] })
     chrome.contextMenus.create({ id: 'securebinOpen', title: 'Open in Editor', parentId: 'securebinRoot', contexts: ['selection'] })
     chrome.contextMenus.create({ id: 'securebinPost', title: 'Post to Pastebin', parentId: 'securebinRoot', contexts: ['selection'] })
   })

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,4 @@
-import { StorageKey, EncryptionMode, CORS_PROXY, DEFAULT_API_KEY, encodeStoredApiKey, decodeStoredApiKey } from './lib/constants'
+import { StorageKey, EncryptionMode, DEFAULT_API_KEY, encodeStoredApiKey, decodeStoredApiKey } from './lib/constants'
 
 const RESTRICTED = /^(chrome:|chrome-extension:|about:|edge:|brave:)/
 
@@ -53,6 +53,34 @@ chrome.action.onClicked.addListener(tab => {
   if (tab.id) chrome.tabs.sendMessage(tab.id, { type: 'SB_TOGGLE' })
 })
 
+// Fetch relay for the injected in-page panel. Content scripts are subject to
+// the page's CORS policy (host permissions don't apply there), so the panel
+// sends its Pastebin requests here; the service worker has host permission
+// for pastebin.com and fetches it directly, CORS-exempt — no proxy involved.
+// Only Pastebin URLs are relayed so this can't be used as a generic fetcher.
+const RELAY_ALLOWED = /^https:\/\/pastebin\.com\//
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type !== 'SB_FETCH') return
+  ;(async () => {
+    try {
+      if (typeof message.url !== 'string' || !RELAY_ALLOWED.test(message.url)) {
+        throw new Error('Blocked non-Pastebin URL')
+      }
+      const response = await fetch(message.url, message.body !== undefined ? {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: message.body,
+      } : undefined)
+      sendResponse({ ok: response.ok, status: response.status, text: await response.text() })
+    } catch (e) {
+      // status 0 signals "the fetch itself failed" — pbFetch turns it into a throw
+      sendResponse({ ok: false, status: 0, text: e instanceof Error ? e.message : 'Network error' })
+    }
+  })()
+  return true // keep the message channel open for the async response
+})
+
 chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   const text = info.selectionText
   if (!text) return
@@ -94,7 +122,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
       body.append('api_dev_key', apiKey)
       body.append('api_paste_code', text)
       body.append('api_option', 'paste')
-      const response = await fetch(`${CORS_PROXY}https://pastebin.com/api/api_post.php`, {
+      const response = await fetch('https://pastebin.com/api/api_post.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body,

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -24,7 +24,7 @@ export default function NavBar() {
         ) : (
           <img
             src={isDark ? '/securebinlogo_dark.svg' : '/securebinlogo.svg'}
-            alt="SecureBin"
+            alt="securebin"
             className="h-5"
           />
         )}

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -4,6 +4,9 @@ import { MemoryRouter } from 'react-router-dom';
 import App from '../App';
 import styles from '../index.css?inline';
 
+// Injected on demand via chrome.scripting.executeScript (activeTab gesture),
+// which can run more than once on the same tab — mount only once.
+if (!(window as any).__SECUREBIN_INJECTED__) {
 (window as any).__SECUREBIN_INJECTED__ = true;
 
 const host = document.createElement('div');
@@ -193,3 +196,5 @@ chrome.runtime.onMessage.addListener(message => {
 window.addEventListener('securebin:close', () => {
   panel.style.display = 'none';
 });
+
+} // end single-injection guard

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -35,7 +35,6 @@ export const MAX_ENC_PASTEBIN_PLAINTEXT_LENGTH =
 export const MAX_ENC_TEXT_LENGTH = 512 * 1024                         // local encrypt / decrypt only (same ceiling)
 export const PASTEBIN_API_KEY_LENGTH = 32
 export const PASTEBIN_BASE_URL = 'pastebin.com'
-export const CORS_PROXY = 'https://cors.securebin.workers.dev/?'
 export const CIPHER_PREFIX = 'C_TXT'
 
 export enum EditorAction {

--- a/src/lib/pastebin.e2e.test.ts
+++ b/src/lib/pastebin.e2e.test.ts
@@ -6,16 +6,18 @@
  *
  * Run with:
  *   npx vitest run src/lib/pastebin.e2e.test.ts
+ *
+ * Note: in Node there is no CORS, so pastebin.ts takes its direct-fetch path —
+ * the same one the popup and background service worker use in the extension.
  */
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { postPastebin, getPastebin, isValidDevKey } from './pastebin'
-import { CORS_PROXY } from './constants'
 
 const API_KEY = process.env.PASTEBIN_API_KEY ?? ''
 const SKIP = !API_KEY
 
 // Unique marker so we can verify the paste was actually stored
-const TEST_CONTENT = `SecureBin e2e test — ${new Date().toISOString()}`
+const TEST_CONTENT = `securebin e2e test — ${new Date().toISOString()}`
 
 // ─── 1. Sanity: environment ───────────────────────────────────────────────────
 
@@ -26,18 +28,12 @@ describe('environment', () => {
     expect(API_KEY, 'Set PASTEBIN_API_KEY in .env').toBeTruthy()
     expect(API_KEY.length).toBeGreaterThan(0)
   })
-
-  it('CORS_PROXY uses the cloudflare-cors-anywhere ?<target-url> format', () => {
-    // Format: https://proxy/?https://target.com  (NOT ?uri=)
-    expect(CORS_PROXY).toContain('cors.securebin.workers.dev/?')
-    expect(CORS_PROXY).not.toContain('?uri=')
-  })
 })
 
-// ─── 2. Direct Pastebin (no proxy) ───────────────────────────────────────────
-// Isolates whether the API key itself is valid before involving the proxy.
+// ─── 2. Raw fetch against the Pastebin API ───────────────────────────────────
+// Isolates whether the API key itself is valid before involving pastebin.ts.
 
-describe('Pastebin API — direct (no proxy)', { skip: SKIP }, () => {
+describe('Pastebin API — raw fetch', { skip: SKIP }, () => {
   it('key is accepted by Pastebin userdetails endpoint', async () => {
     const body = new URLSearchParams()
     body.append('api_dev_key', API_KEY)
@@ -49,7 +45,7 @@ describe('Pastebin API — direct (no proxy)', { skip: SKIP }, () => {
       body,
     })
     const text = await res.text()
-    console.log('[direct userdetails]', text.slice(0, 120))
+    console.log('[raw userdetails]', text.slice(0, 120))
 
     // A valid dev key returns "invalid api_user_key" (user key not provided, not dev key)
     expect(text).not.toContain('invalid api_dev_key')
@@ -67,41 +63,15 @@ describe('Pastebin API — direct (no proxy)', { skip: SKIP }, () => {
       body,
     })
     const text = await res.text()
-    console.log('[direct post]', text)
+    console.log('[raw post]', text)
 
     expect(text).toMatch(/^https:\/\/pastebin\.com\//)
   }, 15_000)
 })
 
-// ─── 3. CORS proxy reachability ──────────────────────────────────────────────
+// ─── 3. Full stack: postPastebin + getPastebin ───────────────────────────────
 
-describe('CORS proxy', () => {
-  it('proxy is reachable and does not return an error page', async () => {
-    // Hit the proxy info page (no ?uri target) — should return the usage text,
-    // NOT a Cloudflare 1101 "Worker threw exception" page.
-    const res = await fetch('https://cors.securebin.workers.dev/')
-    const text = await res.text()
-    console.log('[proxy info page]', text.slice(0, 120))
-
-    expect(text).not.toContain('Worker threw exception')
-    expect(text).not.toContain('<!DOCTYPE html>\n<!--[if lt IE')
-  }, 15_000)
-
-  it('proxy forwards a GET request correctly', async () => {
-    // robots.txt is stable — individual pastes get deleted over time and 404
-    const target = 'https://pastebin.com/robots.txt'
-    const url = `${CORS_PROXY}${target}`
-    console.log('[proxy GET url]', url)
-
-    const res = await fetch(url)
-    console.log('[proxy GET status]', res.status)
-    expect(res.ok).toBe(true)
-  }, 15_000)
-})
-
-// ─── 4. Full stack: postPastebin + getPastebin via proxy ─────────────────────
-
-describe('postPastebin + getPastebin via CORS proxy', { skip: SKIP }, () => {
+describe('postPastebin + getPastebin', { skip: SKIP }, () => {
   let pasteUrl = ''
 
   it('isValidDevKey returns true for the configured key', async () => {

--- a/src/lib/pastebin.ts
+++ b/src/lib/pastebin.ts
@@ -1,10 +1,39 @@
-import { CORS_PROXY } from './constants'
+// All Pastebin traffic goes straight to pastebin.com — no proxy. Extension
+// contexts (popup, service worker) are exempt from CORS for hosts listed in
+// host_permissions, so they fetch directly. The injected in-page panel runs
+// in the content-script world, where the page's CORS policy applies and host
+// permissions do not, so it relays requests to the background service worker
+// (SB_FETCH in background.ts) which performs the same direct fetch.
 
-// Build a proxied URL using the cloudflare-cors-anywhere format:
-// https://cors.securebin.workers.dev/?https://target.com/path
-// The target URL is the raw query string — no ?uri= key, no encoding.
-function proxied(target: string): string {
-  return `${CORS_PROXY}${target}`
+interface PbResponse {
+  ok: boolean
+  status: number
+  text: string
+}
+
+function isInjectedContext(): boolean {
+  return typeof window !== 'undefined' && (window as any).__SECUREBIN_INJECTED__ === true
+}
+
+async function pbFetch(url: string, body?: URLSearchParams): Promise<PbResponse> {
+  if (isInjectedContext()) {
+    const res: PbResponse | undefined = await chrome.runtime.sendMessage({
+      type: 'SB_FETCH',
+      url,
+      body: body?.toString(),
+    })
+    if (!res) throw new Error('No response from the securebin background service')
+    // status 0 = the background fetch itself failed (network error) — mirror
+    // the direct path, where fetch() rejects instead of resolving
+    if (res.status === 0) throw new Error(res.text || 'Network error')
+    return res
+  }
+  const response = await fetch(url, body ? {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  } : undefined)
+  return { ok: response.ok, status: response.status, text: await response.text() }
 }
 
 const PASTEBIN_API = 'https://pastebin.com/api/api_post.php'
@@ -27,19 +56,13 @@ export async function postPastebin(
   if (options?.expiry) body.append('api_paste_expire_date', options.expiry)
   if (options?.privacy !== undefined) body.append('api_paste_private', options.privacy)
 
-  const response = await fetch(proxied(PASTEBIN_API), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body,
-  })
-
-  const text = await response.text()
+  const { ok, status, text } = await pbFetch(PASTEBIN_API, body)
 
   // A non-2xx status carries an HTML error page — don't surface that as the
   // error message. Pastebin API errors come back as HTTP 200 with a short
   // "Bad API request..." body, which is worth showing verbatim.
-  if (!response.ok) {
-    throw new Error(`Pastebin request failed (HTTP ${response.status})`)
+  if (!ok) {
+    throw new Error(`Pastebin request failed (HTTP ${status})`)
   }
   if (text.startsWith('Bad API request') || text.startsWith('CLOUDFLARE')) {
     throw new Error(text)
@@ -52,14 +75,13 @@ export async function getPastebin(link: string): Promise<string> {
   const parts = link.trim().split('/')
   const id = parts[parts.length - 1] || parts[parts.length - 2]
 
-  const response = await fetch(proxied(`https://pastebin.com/raw/${id}`))
-  const text = await response.text()
+  const { ok, status, text } = await pbFetch(`https://pastebin.com/raw/${id}`)
 
-  if (!response.ok) {
+  if (!ok) {
     throw new Error(
-      response.status === 404
+      status === 404
         ? 'Paste not found — it may have expired or been removed'
-        : `Could not fetch paste (HTTP ${response.status})`,
+        : `Could not fetch paste (HTTP ${status})`,
     )
   }
   if (text.startsWith('Bad API request') || text.startsWith('CLOUDFLARE')) {
@@ -96,14 +118,9 @@ export async function isValidDevKey(apiKey: string): Promise<boolean> {
   body.append('api_option', 'userdetails')
 
   try {
-    const response = await fetch(proxied(PASTEBIN_API), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body,
-    })
+    const { text } = await pbFetch(PASTEBIN_API, body)
     // A valid dev key returns "Bad API request, invalid api_user_key" (user key missing).
     // An invalid dev key returns "Bad API request, invalid api_dev_key".
-    const text = await response.text()
     return !text.includes('invalid api_dev_key')
   } catch {
     return false
@@ -144,13 +161,8 @@ export async function loginPastebin(apiKey: string, username: string, password: 
   body.append('api_user_name', username)
   body.append('api_user_password', password)
 
-  const response = await fetch(proxied(PASTEBIN_LOGIN), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body,
-  })
-  const text = await response.text()
-  if (!response.ok || text.startsWith('Bad API request')) throw new Error(text)
+  const { ok, text } = await pbFetch(PASTEBIN_LOGIN, body)
+  if (!ok || text.startsWith('Bad API request')) throw new Error(text)
   return text.trim()
 }
 
@@ -162,13 +174,8 @@ export async function deletePastebin(apiKey: string, userKey: string, pasteKey: 
   body.append('api_paste_key', pasteKey)
   body.append('api_option', 'delete')
 
-  const response = await fetch(proxied(PASTEBIN_API), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body,
-  })
-  const text = await response.text()
-  if (!response.ok || text.startsWith('Bad API request')) throw new Error(text)
+  const { ok, text } = await pbFetch(PASTEBIN_API, body)
+  if (!ok || text.startsWith('Bad API request')) throw new Error(text)
 }
 
 /** List the logged-in user's pastes (max 1000) */
@@ -179,13 +186,8 @@ export async function listPastes(apiKey: string, userKey: string, limit = 50): P
   body.append('api_option', 'list')
   body.append('api_results_limit', String(Math.min(limit, 1000)))
 
-  const response = await fetch(proxied(PASTEBIN_API), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body,
-  })
-  const text = await response.text()
-  if (!response.ok || text.startsWith('Bad API request')) throw new Error(text)
+  const { ok, text } = await pbFetch(PASTEBIN_API, body)
+  if (!ok || text.startsWith('Bad API request')) throw new Error(text)
   // No pastes returns "No pastes found."
   if (text.trim() === 'No pastes found.') return []
   return parseXmlPasteList(text)
@@ -198,13 +200,8 @@ export async function getUserDetails(apiKey: string, userKey: string): Promise<U
   body.append('api_user_key', userKey)
   body.append('api_option', 'userdetails')
 
-  const response = await fetch(proxied(PASTEBIN_API), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body,
-  })
-  const text = await response.text()
-  if (!response.ok || text.startsWith('Bad API request')) throw new Error(text)
+  const { ok, text } = await pbFetch(PASTEBIN_API, body)
+  if (!ok || text.startsWith('Bad API request')) throw new Error(text)
   return parseXmlUserDetails(text)
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="@crxjs/vite-plugin/client" />
 
 interface ImportMetaEnv {
   /** Bundled default Pastebin dev key, set in .env.local (never committed). */


### PR DESCRIPTION
Three changes for the 2.0.2 store submission:

## Lowercase branding
Brand shows as lowercase **securebin** (or "securebin: Powerful Pastebin Tool") in every user-visible surface: manifest name, action title, popup title, context-menu root, and logo alt text.

## CORS proxy removed — no user traffic through first-party servers
All Pastebin traffic goes directly from the browser to pastebin.com. Extension contexts fetch it directly (CORS-exempt via host permission); the injected panel relays through the service worker (`SB_FETCH`, pastebin.com-only allowlist). `cors.securebin.workers.dev` is deleted from the manifest and the worker can be decommissioned after release.

## Broad host permissions eliminated (fixes the CWS in-depth-review flag)
The `<all_urls>` content script and the `tabs` permission are gone. The panel is now injected on demand via `chrome.scripting.executeScript`, authorized by the `activeTab` grant from the user's toolbar/context-menu gesture. Restricted pages (chrome://, Web Store) fall back to the popup via `setPopup`/`openPopup` at gesture time instead of `tabs`-powered popup syncing. Install prompt shrinks to essentially "Read and change your data on pastebin.com" + clipboard, and the panel now also works on tabs that were already open at install time.

Final manifest requests: `storage`, `contextMenus`, `clipboardWrite`, `clipboardRead`, `activeTab`, `scripting`, host `https://pastebin.com/*` — nothing else.

## Verification
- `npm test`: 60 passed.
- Live e2e (`PASTEBIN_API_KEY` set): 6/6 — real paste posted and fetched back through the direct path.
- `npm run test:relay` (`scripts/verify-relay.mjs`, Chrome for Testing driving the real build): service worker injection succeeds **only** on the permitted tab and is refused on example.com; the relay round-trips a real paste from the injected content-script world; extension-page fetches hit pastebin.com with no CORS error; non-Pastebin relay URLs are blocked. 9/9 checks.
- Two adversarial multi-agent review passes over the diffs: zero confirmed findings.

Version bumped to **2.0.2** (supersedes the 2.0.1 draft on the Chrome Web Store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)