### PR TITLE
Fix injected-panel event race, restore decrypt flow, add decrypted-content view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,8 @@ fabric.properties
 
 node_modules
 build
+# Chrome for Testing installed by the verify scripts
+.chrome/
 package-lock.json
 yarn.lock
 yarn.lock

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "securebin: Powerful Pastebin Tool",
   "description": "Securely encrypt your text on Pastebin.com",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "manifest_version": 3,
   "action": {
     "default_title": "Open securebin"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint . --fix",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:relay": "node scripts/verify-relay.mjs"
+    "test:relay": "node scripts/verify-relay.mjs",
+    "test:ui": "node scripts/verify-ui.mjs"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "securebin",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/verify-ui.mjs
+++ b/scripts/verify-ui.mjs
@@ -11,12 +11,18 @@
  *   3. Decrypt: pasting a ciphertext must flip the action button to
  *      "Decrypt"; confirming the passkey must open the decrypted-content view
  *      with the plaintext.
+ *   4. Paste link (needs PASTEBIN_API_KEY): pasting a pastebin.com link must
+ *      default the button to "Open Paste"; opening an encrypted paste must
+ *      hand off to the passkey prompt and land on the decrypted view; opening
+ *      a plain paste must load its content into the editor.
  *
  * Requires:
  *   npm run build
  *   CHROME_PATH=<Chrome for Testing binary> (branded Chrome ≥137 ignores
  *     --load-extension; npx @puppeteer/browsers install chrome@stable)
  * Optional:
+ *   PASTEBIN_API_KEY=<key> to run the live paste-link checks (posts two
+ *     unlisted pastes)
  *   UI_SHOTS_DIR=<dir> to save screenshots of each verified state
  * Run:
  *   npm run test:ui
@@ -30,6 +36,7 @@ import fs from 'node:fs'
 const DIST = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist')
 const CHROME = process.env.CHROME_PATH
 const SHOTS = process.env.UI_SHOTS_DIR ?? ''
+const API_KEY = process.env.PASTEBIN_API_KEY ?? ''
 
 if (!CHROME || !fs.existsSync(CHROME)) {
   console.error('Set CHROME_PATH to a Chrome for Testing binary (npx @puppeteer/browsers install chrome@stable)')
@@ -127,6 +134,20 @@ const pageHelpers = `
       // Primary ActionBar button = the rounded-left half of the split button
       const b = this.buttons().find(b => b.className.includes('rounded-l-full'))
       return b ? b.textContent.trim() : ''
+    },
+    async waitActionLabel(label, timeoutMs = 4000) {
+      const start = Date.now()
+      while (Date.now() - start < timeoutMs) {
+        if (this.actionLabel() === label) return true
+        await new Promise(r => setTimeout(r, 100))
+      }
+      return this.actionLabel()
+    },
+    clickAction() {
+      const b = this.buttons().find(b => b.className.includes('rounded-l-full'))
+      if (!b) return false
+      b.click()
+      return true
     },
   }
 `
@@ -306,6 +327,77 @@ try {
   }, secret)
   await shot(page2, '6-open-in-editor-roundtrip')
   check('Open in Editor loads the plaintext back into the editor', roundTripped)
+
+  // ── 4. Paste link → Open Paste → auto-decrypt handoff (needs API key) ─────
+  if (API_KEY) {
+    const postViaSW = (code) => sw.evaluate(async (apiKey, pasteCode) => {
+      const body = new URLSearchParams({
+        api_dev_key: apiKey, api_paste_code: pasteCode, api_option: 'paste', api_paste_private: '1',
+      })
+      const r = await fetch('https://pastebin.com/api/api_post.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      })
+      return (await r.text()).trim()
+    }, API_KEY, code)
+    const isPasteUrl = u => /^https:\/\/pastebin\.com\//.test(u)
+
+    // Encrypted paste: link → Open Paste → passkey prompt → decrypted view
+    const linkSecret = 'link secret — securebin ui verification'
+    const linkPass = 'link-verify-pass'
+    const encUrl = await postViaSW(await makeCiphertext(linkSecret, linkPass))
+    check('encrypted paste posted for the link test', isPasteUrl(encUrl), encUrl.slice(0, 80))
+
+    if (isPasteUrl(encUrl)) {
+      await page2.evaluate(u => window.__sb.setTextarea(u), encUrl)
+      const openLabel = await page2.evaluate(() => window.__sb.waitActionLabel('Open Paste'))
+      check('pasted link defaults the button to Open Paste', openLabel === true, openLabel === true ? '' : `label: "${openLabel}"`)
+
+      await page2.evaluate(() => window.__sb.clickAction())
+      const autoDialog = await page2.evaluate(() => window.__sb.waitForText('Decryption Key', 10000))
+      await shot(page2, '7-open-link-auto-decrypt')
+      check('opening an encrypted paste auto-opens the passkey prompt', autoDialog)
+
+      await page2.evaluate(k => window.__sb.setInput('decryption key', k), linkPass)
+      await page2.evaluate(() => {
+        const buttons = window.__sb.buttons().filter(b => b.textContent.trim() === 'Decrypt')
+        buttons[buttons.length - 1]?.click()
+      })
+      const linkDecrypted = await page2.evaluate(async s => {
+        const ok = await window.__sb.waitForText('Decrypted successfully')
+        return ok && window.__sb.text().includes(s)
+      }, linkSecret)
+      await shot(page2, '8-link-decrypted')
+      check('link → open → decrypt lands on the decrypted view', linkDecrypted)
+      // Back to the editor for the plain-paste check
+      await page2.evaluate(() => window.__sb.clickButton('Open in Editor'))
+    }
+
+    // Plain paste: link → Open Paste → content loads into the editor
+    const plainBody = 'plain paste body 4471'
+    const plainUrl = await postViaSW(plainBody)
+    check('plain paste posted for the link test', isPasteUrl(plainUrl), plainUrl.slice(0, 80))
+
+    if (isPasteUrl(plainUrl)) {
+      await page2.evaluate(u => window.__sb.setTextarea(u), plainUrl)
+      await page2.evaluate(() => window.__sb.waitActionLabel('Open Paste'))
+      await page2.evaluate(() => window.__sb.clickAction())
+      const opened = await page2.evaluate(async b => {
+        const start = Date.now()
+        while (Date.now() - start < 10000) {
+          const ta = window.__sb.root()?.querySelector('textarea')
+          if (ta && ta.value.trim() === b) return true
+          await new Promise(r => setTimeout(r, 100))
+        }
+        return false
+      }, plainBody)
+      await shot(page2, '9-open-plain-paste')
+      check('opening a plain paste loads its content into the editor', opened)
+    }
+  } else {
+    console.log('⏭  PASTEBIN_API_KEY not set — skipping the live paste-link checks')
+  }
 } finally {
   await browser.close()
 }

--- a/scripts/verify-ui.mjs
+++ b/scripts/verify-ui.mjs
@@ -1,0 +1,314 @@
+/**
+ * Live UI verification of the injected panel flows that regressed with
+ * on-demand injection (2.0.3) and the decrypt UX:
+ *
+ *   1. Quick-post: fresh injection + immediate SB_OPEN{quickPostLoading} must
+ *      show the branded "Posting to Pastebin…" loading screen (the event used
+ *      to be dispatched before React mounted and was lost), and the fake
+ *      result message must land on the result page.
+ *   2. Open in Editor: fresh injection + immediate SB_OPEN{pendingText} must
+ *      put the text in the editor (same race).
+ *   3. Decrypt: pasting a ciphertext must flip the action button to
+ *      "Decrypt"; confirming the passkey must open the decrypted-content view
+ *      with the plaintext.
+ *
+ * Requires:
+ *   npm run build
+ *   CHROME_PATH=<Chrome for Testing binary> (branded Chrome ≥137 ignores
+ *     --load-extension; npx @puppeteer/browsers install chrome@stable)
+ * Optional:
+ *   UI_SHOTS_DIR=<dir> to save screenshots of each verified state
+ * Run:
+ *   npm run test:ui
+ */
+import puppeteer from 'puppeteer-core'
+import { webcrypto } from 'node:crypto'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import fs from 'node:fs'
+
+const DIST = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist')
+const CHROME = process.env.CHROME_PATH
+const SHOTS = process.env.UI_SHOTS_DIR ?? ''
+
+if (!CHROME || !fs.existsSync(CHROME)) {
+  console.error('Set CHROME_PATH to a Chrome for Testing binary (npx @puppeteer/browsers install chrome@stable)')
+  process.exit(1)
+}
+if (!fs.existsSync(path.join(DIST, 'manifest.json'))) {
+  console.error(`No build at ${DIST} — run \`npm run build\` first`)
+  process.exit(1)
+}
+if (SHOTS) fs.mkdirSync(SHOTS, { recursive: true })
+
+const loaderFile = fs.readdirSync(path.join(DIST, 'assets')).find(f => f.includes('-loader-'))
+if (!loaderFile) {
+  console.error('No content-script loader found in dist/assets — did the build change?')
+  process.exit(1)
+}
+const LOADER = `assets/${loaderFile}`
+
+let failures = 0
+function check(name, ok, detail = '') {
+  console.log(`${ok ? '✅' : '❌'} ${name}${detail ? ` — ${detail}` : ''}`)
+  if (!ok) failures++
+}
+
+/** securebin-compatible password ciphertext (PBKDF2-SHA256 → AES-GCM). */
+async function makeCiphertext(plaintext, passkey) {
+  const enc = new TextEncoder()
+  const salt = webcrypto.getRandomValues(new Uint8Array(16))
+  const iv = webcrypto.getRandomValues(new Uint8Array(12))
+  const material = await webcrypto.subtle.importKey('raw', enc.encode(passkey), 'PBKDF2', false, ['deriveKey'])
+  const key = await webcrypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 10000, hash: 'SHA-256' },
+    material,
+    { name: 'AES-GCM', length: 128 },
+    true,
+    ['encrypt'],
+  )
+  const out = new Uint8Array(await webcrypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, enc.encode(plaintext)))
+  const b64 = u8 => Buffer.from(u8).toString('base64')
+  return JSON.stringify({
+    C_TXT: b64(out.slice(0, -16)),
+    IV: b64(iv),
+    Mode: 'AES-GCM',
+    Tag: b64(out.slice(-16)),
+    Salt: b64(salt),
+    Length: 16,
+  })
+}
+
+// Runs inside the PAGE main world. The shadow root is open, so the panel DOM
+// is reachable; events dispatched here bubble to the React listeners that the
+// content script attached in its isolated world (the DOM is shared).
+const pageHelpers = `
+  window.__sb = {
+    root() { return document.getElementById('securebin-root')?.shadowRoot ?? null },
+    text() {
+      const root = this.root()
+      if (!root) return ''
+      const values = [...root.querySelectorAll('input, textarea')].map(el => el.value).join('\\n')
+      return root.textContent + '\\n' + values
+    },
+    async waitForText(needle, timeoutMs = 6000) {
+      const start = Date.now()
+      while (Date.now() - start < timeoutMs) {
+        if (this.text().includes(needle)) return true
+        await new Promise(r => setTimeout(r, 100))
+      }
+      return false
+    },
+    buttons() { return [...(this.root()?.querySelectorAll('button') ?? [])] },
+    clickButton(label) {
+      const b = this.buttons().find(b => b.textContent.trim() === label)
+      if (!b) return false
+      b.click()
+      return true
+    },
+    setInput(placeholderPart, value) {
+      const input = [...(this.root()?.querySelectorAll('input') ?? [])]
+        .find(i => (i.placeholder ?? '').includes(placeholderPart))
+      if (!input) return false
+      const set = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set
+      set.call(input, value)
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      return true
+    },
+    setTextarea(value) {
+      const ta = this.root()?.querySelector('textarea')
+      if (!ta) return false
+      const set = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set
+      set.call(ta, value)
+      ta.dispatchEvent(new Event('input', { bubbles: true }))
+      return true
+    },
+    actionLabel() {
+      // Primary ActionBar button = the rounded-left half of the split button
+      const b = this.buttons().find(b => b.className.includes('rounded-l-full'))
+      return b ? b.textContent.trim() : ''
+    },
+  }
+`
+
+async function shot(page, name) {
+  if (!SHOTS) return
+  await page.screenshot({ path: path.join(SHOTS, `${name}.png`), clip: { x: 820, y: 0, width: 460, height: 640 } })
+}
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME,
+  headless: true,
+  defaultViewport: { width: 1280, height: 800 },
+  args: [
+    `--disable-extensions-except=${DIST}`,
+    `--load-extension=${DIST}`,
+    '--no-first-run',
+  ],
+})
+
+try {
+  const swTarget = await browser.waitForTarget(
+    t => t.type() === 'service_worker' && t.url().startsWith('chrome-extension://'),
+    { timeout: 20_000 },
+  )
+  check('service worker running', true, new URL(swTarget.url()).host)
+  const sw = await swTarget.worker()
+
+  // Mirrors background.ts: inject, then retry sendMessage until the content
+  // script's listener is up — exactly the timing a real context-menu click gets.
+  const injectAndSend = (tabUrl, message) => sw.evaluate(async (url, msg, loader) => {
+    const tabs = await chrome.tabs.query({})
+    const tab = tabs.find(t => t.url === url)
+    if (!tab) return { error: `tab not found: ${url}` }
+    await chrome.scripting.executeScript({ target: { tabId: tab.id }, files: [loader] })
+    for (let attempt = 0; ; attempt++) {
+      try { return { response: await chrome.tabs.sendMessage(tab.id, msg) ?? null } }
+      catch (e) {
+        if (attempt >= 20) return { error: String(e?.message ?? e) }
+        await new Promise(r => setTimeout(r, 100))
+      }
+    }
+  }, tabUrl, message, LOADER)
+
+  const sendToTab = (tabUrl, message) => sw.evaluate(async (url, msg) => {
+    const tabs = await chrome.tabs.query({})
+    const tab = tabs.find(t => t.url === url)
+    if (!tab) return { error: `tab not found: ${url}` }
+    try { return { response: await chrome.tabs.sendMessage(tab.id, msg) ?? null } }
+    catch (e) { return { error: String(e?.message ?? e) } }
+  }, tabUrl, message)
+
+  // ── 1. Quick-post: loading screen must appear on a fresh injection ────────
+  const page = await browser.newPage()
+  await page.goto('https://pastebin.com/robots.txt', { waitUntil: 'networkidle2' })
+  await page.evaluate(pageHelpers)
+
+  const qp = await injectAndSend('https://pastebin.com/robots.txt', { type: 'SB_OPEN', quickPostLoading: true })
+  check('quick-post SB_OPEN delivered to fresh injection', !qp.error, qp.error)
+
+  const loadingShown = await page.evaluate(() => window.__sb.waitForText('Posting to Pastebin'))
+  await shot(page, '1-quick-post-loading')
+  check('branded loading screen visible (event survived the mount race)', loadingShown)
+
+  const fakeUrl = 'https://pastebin.com/FAKEQP01'
+  await sendToTab('https://pastebin.com/robots.txt', {
+    type: 'SB_QUICK_POST_RESULT',
+    payload: { url: fakeUrl, error: null, text: 'quick post body', timestamp: 0 },
+  })
+  const resultShown = await page.evaluate(u => window.__sb.waitForText(u), fakeUrl)
+  await shot(page, '2-quick-post-result')
+  check('quick-post result lands on the result page', resultShown)
+
+  // ── 2. Open in Editor: pending text must survive a fresh injection ────────
+  const page2 = await browser.newPage()
+  await page2.goto('https://pastebin.com/', { waitUntil: 'networkidle2' })
+  await page2.evaluate(pageHelpers)
+
+  const marker = 'context menu selection 8814'
+  const st = await injectAndSend('https://pastebin.com/', { type: 'SB_OPEN', pendingText: marker })
+  check('set-text SB_OPEN delivered to fresh injection', !st.error, st.error)
+  const textShown = await page2.evaluate(async m => {
+    const ok = await window.__sb.waitForText(m)
+    return ok && (window.__sb.root()?.querySelector('textarea')?.value ?? '').includes(m)
+  }, marker)
+  await shot(page2, '3-open-in-editor')
+  check('pending text appears in the editor (event survived the mount race)', textShown)
+
+  // ── 3. Decrypt flow: paste ciphertext → Decrypt button → decrypted view ───
+  const secret = 'attack at dawn — securebin ui verification'
+  const passkey = 'ui-verify-passkey'
+  const ciphertext = await makeCiphertext(secret, passkey)
+
+  const typed = await page2.evaluate(ct => window.__sb.setTextarea(ct), ciphertext)
+  check('ciphertext entered in the editor', typed)
+
+  const flipped = await page2.evaluate(async () => {
+    const start = Date.now()
+    while (Date.now() - start < 4000) {
+      if (window.__sb.actionLabel() === 'Decrypt') return true
+      await new Promise(r => setTimeout(r, 100))
+    }
+    return window.__sb.actionLabel()
+  })
+  await shot(page2, '4-decrypt-detected')
+  check('action button flips to Decrypt on ciphertext paste', flipped === true, flipped === true ? '' : `label: "${flipped}"`)
+
+  const decryptClicked = await page2.evaluate(() => {
+    const b = window.__sb.buttons().find(b => b.className.includes('rounded-l-full'))
+    if (!b) return false
+    b.click()
+    return true
+  })
+  check('Decrypt button clicked', decryptClicked)
+
+  const dialogShown = await page2.evaluate(() => window.__sb.waitForText('Decryption Key'))
+  check('passkey dialog opens', dialogShown)
+
+  const keyEntered = await page2.evaluate(k => window.__sb.setInput('decryption key', k), passkey)
+  check('passkey entered', keyEntered)
+  await page2.evaluate(() => {
+    // The dialog's confirm button (label "Decrypt") lives in the portal target
+    const buttons = window.__sb.buttons().filter(b => b.textContent.trim() === 'Decrypt')
+    buttons[buttons.length - 1]?.click()
+  })
+
+  const decryptedShown = await page2.evaluate(async s => {
+    const ok = await window.__sb.waitForText('Decrypted successfully')
+    return ok && window.__sb.text().includes(s)
+  }, secret)
+  await shot(page2, '5-decrypted-view')
+  check('decrypted-content view shows the plaintext', decryptedShown)
+
+  const notPersisted = await page2.evaluate(() => window.__sb.text().includes('never saved to history'))
+  check('view states decrypted content is not saved to history', notPersisted)
+
+  // Closing the panel must drop the decrypted content — reopening shows the
+  // editor (with the ciphertext draft), never the plaintext
+  await sendToTab('https://pastebin.com/', { type: 'SB_TOGGLE' })  // hide
+  await sendToTab('https://pastebin.com/', { type: 'SB_TOGGLE' })  // show again
+  const droppedOnClose = await page2.evaluate(async s => {
+    const start = Date.now()
+    while (Date.now() - start < 4000) {
+      const t = window.__sb.text()
+      if (!t.includes('Decrypted successfully') && !t.includes(s)) return true
+      await new Promise(r => setTimeout(r, 100))
+    }
+    return false
+  }, secret)
+  await shot(page2, '5b-reopen-after-close')
+  check('closing the panel drops the decrypted content', droppedOnClose)
+
+  // Decrypt again for the Open in Editor round-trip
+  await page2.evaluate(() => {
+    const b = window.__sb.buttons().find(b => b.className.includes('rounded-l-full'))
+    b?.click()
+  })
+  await page2.evaluate(() => window.__sb.waitForText('Decryption Key'))
+  await page2.evaluate(k => window.__sb.setInput('decryption key', k), passkey)
+  await page2.evaluate(() => {
+    const buttons = window.__sb.buttons().filter(b => b.textContent.trim() === 'Decrypt')
+    buttons[buttons.length - 1]?.click()
+  })
+  const redecrypted = await page2.evaluate(() => window.__sb.waitForText('Decrypted successfully'))
+  check('re-decrypting after reopen works', redecrypted)
+
+  // Open in Editor from the decrypted view round-trips the plaintext
+  await page2.evaluate(() => window.__sb.clickButton('Open in Editor'))
+  const roundTripped = await page2.evaluate(async s => {
+    const start = Date.now()
+    while (Date.now() - start < 4000) {
+      const ta = window.__sb.root()?.querySelector('textarea')
+      if (ta && ta.value.includes(s)) return true
+      await new Promise(r => setTimeout(r, 100))
+    }
+    return false
+  }, secret)
+  await shot(page2, '6-open-in-editor-roundtrip')
+  check('Open in Editor loads the plaintext back into the editor', roundTripped)
+} finally {
+  await browser.close()
+}
+
+console.log(failures === 0 ? '\nAll UI checks passed.' : `\n${failures} check(s) FAILED`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useRef } from 'react'
 import { Routes, Route, useNavigate, useLocation } from 'react-router-dom'
 import { useStore, resolveTheme, type HistoryItem } from './lib/store'
+import { panelBus, emitPanelEvent } from './lib/panel-bus'
 import { EditorAction } from './lib/constants'
 import { detectAction } from './lib/editor-utils'
 import { detectLanguage } from './lib/detect-language'
@@ -17,6 +18,7 @@ import PastebinAccount from './routes/PastebinAccount'
 import CloudPasteDetail from './routes/CloudPasteDetail'
 import PasteNameConfig from './routes/PasteNameConfig'
 import QuickPostLoading from './routes/QuickPostLoading'
+import DecryptResult from './routes/DecryptResult'
 
 // Evaluated at call-time (not module load) so content/index.tsx has set the
 // flag before any component renders, even though ES module imports hoist App
@@ -24,13 +26,16 @@ import QuickPostLoading from './routes/QuickPostLoading'
 export const isInjected = () => !!(window as any).__SECUREBIN_INJECTED__;
 
 // Routes we won't try to restore (transient pages)
-const NON_RESTORABLE_ROUTES = new Set(['/', '/home', '/result', '/quick-post-loading'])
+const NON_RESTORABLE_ROUTES = new Set(['/', '/home', '/result', '/quick-post-loading', '/decrypted'])
 
 export default function App() {
-  const { settings, initialized, initialize, addToHistory, updateDraft } = useStore()
+  const { settings, initialized, initialize, addToHistory, updateDraft, setDecryptResult } = useStore()
   const isDark = resolveTheme(settings.theme) === 'dark'
   const navigate = useNavigate()
   const location = useLocation()
+  // Current location for listeners that must not re-register on route change
+  const locationRef = useRef(location)
+  useEffect(() => { locationRef.current = location }, [location])
 
   useEffect(() => {
     initialize()
@@ -74,23 +79,45 @@ export default function App() {
   // Injected mode: event from content script
   useEffect(() => {
     const handler = (e: Event) => handleSetText((e as CustomEvent).detail ?? '')
-    window.addEventListener('securebin:set-text', handler)
-    return () => window.removeEventListener('securebin:set-text', handler)
+    panelBus.addEventListener('securebin:set-text', handler)
+    return () => panelBus.removeEventListener('securebin:set-text', handler)
   }, [handleSetText])
 
   // Quick-post: show loading overlay while background makes the API call
   useEffect(() => {
     const handler = () => navigate('/quick-post-loading', { replace: true })
-    window.addEventListener('securebin:quick-post-loading', handler)
-    return () => window.removeEventListener('securebin:quick-post-loading', handler)
+    panelBus.addEventListener('securebin:quick-post-loading', handler)
+    return () => panelBus.removeEventListener('securebin:quick-post-loading', handler)
   }, [navigate])
 
   // Quick-post result — injected mode
   useEffect(() => {
     const handler = (e: Event) => handleQuickPostResult((e as CustomEvent).detail)
-    window.addEventListener('securebin:quick-post-result', handler)
-    return () => window.removeEventListener('securebin:quick-post-result', handler)
+    panelBus.addEventListener('securebin:quick-post-result', handler)
+    return () => panelBus.removeEventListener('securebin:quick-post-result', handler)
   }, [handleQuickPostResult])
+
+  // Injected mode: the panel is only hidden, never unmounted, so drop the
+  // decrypted plaintext when it closes — reopening must not reveal it.
+  useEffect(() => {
+    const handler = () => {
+      setDecryptResult(null)
+      if (locationRef.current.pathname === '/decrypted') {
+        navigate('/home', { replace: true })
+      }
+    }
+    panelBus.addEventListener('securebin:panel-hidden', handler)
+    return () => panelBus.removeEventListener('securebin:panel-hidden', handler)
+  }, [setDecryptResult, navigate])
+
+  // Injected mode: the content script buffers app-bound events (quick-post
+  // loading, pending text) until this signal — declared after the listener
+  // effects above so they are registered before any buffered event replays.
+  useEffect(() => {
+    if (initialized && isInjected()) {
+      emitPanelEvent('securebin:app-ready')
+    }
+  }, [initialized])
 
   // Popup mode: read pending data from session after init. Injected mode gets
   // this via window events instead — content scripts can't read session storage.
@@ -174,6 +201,7 @@ export default function App() {
           <Route path="/cloud-paste" element={<CloudPasteDetail />} />
           <Route path="/paste-name" element={<PasteNameConfig />} />
           <Route path="/quick-post-loading" element={<QuickPostLoading />} />
+          <Route path="/decrypted" element={<DecryptResult />} />
         </Routes>
       </main>
     </div>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,6 +2,7 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import { PenLine, Files, Settings, X } from 'lucide-react'
 import { cn } from '@/lib/cn'
 import { useStore, resolveTheme } from '@/lib/store'
+import { emitPanelEvent } from '@/lib/panel-bus'
 import { isInjected } from '../App'
 import SecurebinLogo from './common/SecurebinLogo'
 
@@ -51,7 +52,7 @@ export default function NavBar() {
         })}
         {isInjected() && (
           <button
-            onClick={() => window.dispatchEvent(new CustomEvent('securebin:close'))}
+            onClick={() => emitPanelEvent('securebin:close')}
             className="p-2 rounded-lg text-text-muted hover:text-text-secondary hover:bg-surface-hover transition-all duration-150"
             title="Close"
           >

--- a/src/components/editor/ActionBar.tsx
+++ b/src/components/editor/ActionBar.tsx
@@ -53,15 +53,26 @@ export default function ActionBar({ onAction, loading = false }: ActionBarProps)
         { action: EditorAction.POST_PASTEBIN, icon: Send, label: 'Post (Unencrypted)', disabled: !hasPostKey },
         { action: EditorAction.ENCRYPT, icon: Lock, label: 'Encrypt Only' },
         { action: EditorAction.SAVE_DRAFT, icon: Save, label: 'Save Draft', divider: true },
-        { action: EditorAction.DECRYPT, icon: Unlock, label: 'Decrypt' },
-        ...(isPastebinLink ? [{ action: EditorAction.DECRYPT_PASTEBIN, icon: Unlock, label: 'Decrypt from Link' }] : []),
+        { action: EditorAction.DECRYPT, icon: Unlock, label: 'Decrypt', divider: true },
+        ...(isPastebinLink
+          ? [
+              { action: EditorAction.DECRYPT_PASTEBIN, icon: Unlock, label: 'Decrypt from Link' },
+              { action: EditorAction.OPEN_PASTEBIN, icon: Link, label: 'Open Paste' },
+            ]
+          : []),
       ]
     : [
         { action: EditorAction.POST_PASTEBIN, icon: Send, label: 'Post to Pastebin', disabled: !hasPostKey },
         { action: EditorAction.ENCRYPT_PASTEBIN, icon: KeyRound, label: 'Encrypt & Post', disabled: !hasPostKey },
         { action: EditorAction.ENCRYPT, icon: Lock, label: 'Encrypt Only' },
         { action: EditorAction.SAVE_DRAFT, icon: Save, label: 'Save Draft', divider: true },
-        ...(isPastebinLink ? [{ action: EditorAction.OPEN_PASTEBIN, icon: Link, label: 'Open Paste', divider: true }] : []),
+        { action: EditorAction.DECRYPT, icon: Unlock, label: 'Decrypt', divider: true },
+        ...(isPastebinLink
+          ? [
+              { action: EditorAction.DECRYPT_PASTEBIN, icon: Unlock, label: 'Decrypt from Link' },
+              { action: EditorAction.OPEN_PASTEBIN, icon: Link, label: 'Open Paste' },
+            ]
+          : []),
       ]
 
   const dropdownContent = (

--- a/src/components/editor/TextEditor.tsx
+++ b/src/components/editor/TextEditor.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback } from 'react'
 import { useStore, resolveTheme, type Draft } from '@/lib/store'
 import { EditorAction } from '@/lib/constants'
 import { detectLanguage } from '@/lib/detect-language'
+import { detectActionOnChange } from '@/lib/editor-utils'
 import {
   EditorView,
   EditorState,
@@ -50,6 +51,10 @@ export default function TextEditor() {
   const handleChange = useCallback(
     (text: string) => {
       const partial: Partial<Draft> = { plaintext: text }
+      // Pasted a ciphertext or Pastebin link → flip the action to Decrypt /
+      // Open Paste (and back once the content no longer matches).
+      const action = detectActionOnChange(text, draft.action, settings.default_action)
+      if (action !== undefined) partial.action = action
       // Auto-detect a code language, but never override a format the user
       // picked explicitly (formatLocked) — including an explicit "Plain Text".
       if (draft.format === 'text' && !draft.formatLocked && text.length > 80) {
@@ -62,7 +67,7 @@ export default function TextEditor() {
       }
       updateDraft(partial)
     },
-    [draft.format, draft.formatLocked, updateDraft],
+    [draft.format, draft.formatLocked, draft.action, settings.default_action, updateDraft],
   )
 
   // The CodeMirror update listener is registered once per view, so it must

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { MemoryRouter } from 'react-router-dom';
 import App from '../App';
+import { panelBus, emitPanelEvent } from '../lib/panel-bus';
 import styles from '../index.css?inline';
 
 // Injected on demand via chrome.scripting.executeScript (activeTab gesture),
@@ -175,26 +176,48 @@ ReactDOM.createRoot(appRoot).render(
   </MemoryRouter>
 );
 
+// The panel is injected at gesture time, so background messages (quick-post
+// loading, pending text) usually arrive before React has mounted App's
+// listeners. Buffer app-bound events until App signals readiness. All of this
+// rides panelBus, not window events — see panel-bus.ts for why.
+let appReady = false;
+const pendingAppEvents: Array<{ name: string; detail?: unknown }> = [];
+function dispatchToApp(name: string, detail?: unknown) {
+  if (appReady) emitPanelEvent(name, detail);
+  else pendingAppEvents.push({ name, detail });
+}
+panelBus.addEventListener('securebin:app-ready', () => {
+  appReady = true;
+  while (pendingAppEvents.length) {
+    const { name, detail } = pendingAppEvents.shift()!;
+    emitPanelEvent(name, detail);
+  }
+});
+
+function hidePanel() {
+  panel.style.display = 'none';
+  // Let the app drop sensitive transient state (the decrypted-content view)
+  emitPanelEvent('securebin:panel-hidden');
+}
+
 // Panel show/hide + context menu pending text
 chrome.runtime.onMessage.addListener(message => {
   if (message.type === 'SB_TOGGLE') {
     // Toolbar icon — toggle open/closed
-    const isOpening = panel.style.display === 'none';
-    panel.style.display = isOpening ? 'block' : 'none';
+    if (panel.style.display === 'none') panel.style.display = 'block';
+    else hidePanel();
   } else if (message.type === 'SB_OPEN') {
     panel.style.display = 'block';
     if (message.quickPostLoading) {
-      window.dispatchEvent(new CustomEvent('securebin:quick-post-loading'));
+      dispatchToApp('securebin:quick-post-loading');
     } else if (message.pendingText) {
-      window.dispatchEvent(new CustomEvent('securebin:set-text', { detail: message.pendingText }));
+      dispatchToApp('securebin:set-text', message.pendingText);
     }
   } else if (message.type === 'SB_QUICK_POST_RESULT') {
-    window.dispatchEvent(new CustomEvent('securebin:quick-post-result', { detail: message.payload }));
+    dispatchToApp('securebin:quick-post-result', message.payload);
   }
 });
 
-window.addEventListener('securebin:close', () => {
-  panel.style.display = 'none';
-});
+panelBus.addEventListener('securebin:close', hidePanel);
 
 } // end single-injection guard

--- a/src/lib/editor-utils.test.ts
+++ b/src/lib/editor-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   detectAction,
+  detectActionOnChange,
   getMaxLength,
   isWithinLimit,
   isEncryptionAction,
@@ -163,6 +164,86 @@ describe('detectAction with ENCRYPT default', () => {
 
   it('detects DECRYPT_PASTEBIN for a pastebin.com link (encryption action default)', () => {
     expect(detectAction('https://pastebin.com/abc123', def)).toBe(EditorAction.DECRYPT_PASTEBIN)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// detectActionOnChange — auto-switching as the user types or pastes
+// ---------------------------------------------------------------------------
+
+describe('detectActionOnChange', () => {
+  const def = EditorAction.POST_PASTEBIN
+  const ciphertext = '{"C_TXT":"abc","IV":"def","Mode":"AES-GCM","Tag":"ghi"}'
+
+  it('switches to DECRYPT when a ciphertext is pasted', () => {
+    expect(detectActionOnChange(ciphertext, EditorAction.POST_PASTEBIN, def)).toBe(EditorAction.DECRYPT)
+  })
+
+  it('switches to DECRYPT even when the current action was chosen explicitly', () => {
+    expect(detectActionOnChange(ciphertext, EditorAction.ENCRYPT, def)).toBe(EditorAction.DECRYPT)
+  })
+
+  it('switches to OPEN_PASTEBIN when a pastebin link is pasted (plain default)', () => {
+    expect(detectActionOnChange('https://pastebin.com/abc123', EditorAction.POST_PASTEBIN, def)).toBe(EditorAction.OPEN_PASTEBIN)
+  })
+
+  it('switches to DECRYPT_PASTEBIN when a pastebin link is pasted (encryption default)', () => {
+    expect(detectActionOnChange('https://pastebin.com/abc123', EditorAction.ENCRYPT_PASTEBIN, EditorAction.ENCRYPT_PASTEBIN)).toBe(EditorAction.DECRYPT_PASTEBIN)
+  })
+
+  it('switches back to the default when the ciphertext is removed', () => {
+    expect(detectActionOnChange('plain text now', EditorAction.DECRYPT, def)).toBe(EditorAction.POST_PASTEBIN)
+  })
+
+  it('switches back to the default when the link is removed', () => {
+    expect(detectActionOnChange('plain text now', EditorAction.OPEN_PASTEBIN, def)).toBe(EditorAction.POST_PASTEBIN)
+  })
+
+  it('keeps the current action when nothing content-specific is detected', () => {
+    expect(detectActionOnChange('plain text', EditorAction.POST_PASTEBIN, def)).toBeUndefined()
+  })
+
+  it('never overrides an explicit non-default choice with plain text', () => {
+    // User picked "Encrypt Only", keeps typing plain text — action must not snap back
+    expect(detectActionOnChange('plain text', EditorAction.ENCRYPT, def)).toBeUndefined()
+    expect(detectActionOnChange('plain text', EditorAction.SAVE_DRAFT, def)).toBeUndefined()
+  })
+
+  it('returns undefined when the detected action equals the current one', () => {
+    expect(detectActionOnChange(ciphertext, EditorAction.DECRYPT, def)).toBeUndefined()
+    expect(detectActionOnChange('https://pastebin.com/abc', EditorAction.OPEN_PASTEBIN, def)).toBeUndefined()
+  })
+
+  it('switches between content actions when the content kind changes', () => {
+    // Ciphertext replaced by a pastebin link
+    expect(detectActionOnChange('https://pastebin.com/abc', EditorAction.DECRYPT, def)).toBe(EditorAction.OPEN_PASTEBIN)
+  })
+
+  it('keeps an explicit link-action pick while the text is still a link', () => {
+    // User picked "Decrypt from Link" over the detected "Open Paste" (or vice
+    // versa) — editing the link must not flip it back
+    expect(detectActionOnChange('https://pastebin.com/abc1', EditorAction.DECRYPT_PASTEBIN, def)).toBeUndefined()
+    expect(detectActionOnChange('https://pastebin.com/abc1', EditorAction.OPEN_PASTEBIN, EditorAction.ENCRYPT_PASTEBIN)).toBeUndefined()
+  })
+
+  it('does NOT hijack the action when pastebin.com is merely mentioned in prose', () => {
+    expect(detectActionOnChange('remember to check pastebin.com for the logs', EditorAction.POST_PASTEBIN, def)).toBeUndefined()
+    expect(detectActionOnChange('remember to check pastebin.com for the logs', EditorAction.ENCRYPT, def)).toBeUndefined()
+    expect(detectActionOnChange('see pastebin.com/abc123 in the docs', EditorAction.SAVE_DRAFT, def)).toBeUndefined()
+  })
+
+  it('does NOT hijack the action when C_TXT appears in prose', () => {
+    expect(detectActionOnChange('the C_TXT field holds the ciphertext', EditorAction.POST_PASTEBIN, def)).toBeUndefined()
+  })
+
+  it('accepts raw links and bare-domain paste links', () => {
+    expect(detectActionOnChange('pastebin.com/xyz9', EditorAction.POST_PASTEBIN, def)).toBe(EditorAction.OPEN_PASTEBIN)
+    expect(detectActionOnChange('https://pastebin.com/raw/xyz9', EditorAction.POST_PASTEBIN, def)).toBe(EditorAction.OPEN_PASTEBIN)
+  })
+
+  it('does NOT treat a lookalike domain as a paste link', () => {
+    expect(detectActionOnChange('https://pastebin.com.evil.com/abc', EditorAction.POST_PASTEBIN, def)).toBeUndefined()
+    expect(detectActionOnChange('https://pastebin.community/abc', EditorAction.POST_PASTEBIN, def)).toBeUndefined()
   })
 })
 

--- a/src/lib/editor-utils.test.ts
+++ b/src/lib/editor-utils.test.ts
@@ -5,6 +5,7 @@ import {
   getMaxLength,
   isWithinLimit,
   isEncryptionAction,
+  isCiphertext,
 } from './editor-utils'
 import {
   EditorAction,
@@ -142,8 +143,8 @@ describe('detectAction with ENCRYPT_PASTEBIN default', () => {
     expect(detectAction('hello world', def)).toBe(EditorAction.ENCRYPT_PASTEBIN)
   })
 
-  it('detects DECRYPT_PASTEBIN for a pastebin.com link', () => {
-    expect(detectAction('https://pastebin.com/abc123', def)).toBe(EditorAction.DECRYPT_PASTEBIN)
+  it('detects OPEN_PASTEBIN for a pastebin.com link (open hands off to decrypt for encrypted pastes)', () => {
+    expect(detectAction('https://pastebin.com/abc123', def)).toBe(EditorAction.OPEN_PASTEBIN)
   })
 
   it('detects DECRYPT for cipher prefix regardless of default', () => {
@@ -162,8 +163,28 @@ describe('detectAction with ENCRYPT default', () => {
     expect(detectAction('hello world', def)).toBe(EditorAction.ENCRYPT)
   })
 
-  it('detects DECRYPT_PASTEBIN for a pastebin.com link (encryption action default)', () => {
-    expect(detectAction('https://pastebin.com/abc123', def)).toBe(EditorAction.DECRYPT_PASTEBIN)
+  it('detects OPEN_PASTEBIN for a pastebin.com link (encryption action default)', () => {
+    expect(detectAction('https://pastebin.com/abc123', def)).toBe(EditorAction.OPEN_PASTEBIN)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isCiphertext
+// ---------------------------------------------------------------------------
+
+describe('isCiphertext', () => {
+  it('accepts the JSON blob produced by encrypt()', () => {
+    expect(isCiphertext('{"C_TXT":"abc","IV":"def","Mode":"AES-GCM","Tag":"ghi"}')).toBe(true)
+    expect(isCiphertext('  {"C_TXT":"abc"}  ')).toBe(true)
+  })
+
+  it('rejects prose that merely mentions C_TXT', () => {
+    expect(isCiphertext('the C_TXT field holds the ciphertext')).toBe(false)
+  })
+
+  it('rejects plain text and JSON without the marker', () => {
+    expect(isCiphertext('hello world')).toBe(false)
+    expect(isCiphertext('{"foo":"bar"}')).toBe(false)
   })
 })
 
@@ -187,8 +208,8 @@ describe('detectActionOnChange', () => {
     expect(detectActionOnChange('https://pastebin.com/abc123', EditorAction.POST_PASTEBIN, def)).toBe(EditorAction.OPEN_PASTEBIN)
   })
 
-  it('switches to DECRYPT_PASTEBIN when a pastebin link is pasted (encryption default)', () => {
-    expect(detectActionOnChange('https://pastebin.com/abc123', EditorAction.ENCRYPT_PASTEBIN, EditorAction.ENCRYPT_PASTEBIN)).toBe(EditorAction.DECRYPT_PASTEBIN)
+  it('switches to OPEN_PASTEBIN when a pastebin link is pasted (encryption default)', () => {
+    expect(detectActionOnChange('https://pastebin.com/abc123', EditorAction.ENCRYPT_PASTEBIN, EditorAction.ENCRYPT_PASTEBIN)).toBe(EditorAction.OPEN_PASTEBIN)
   })
 
   it('switches back to the default when the ciphertext is removed', () => {

--- a/src/lib/editor-utils.ts
+++ b/src/lib/editor-utils.ts
@@ -12,11 +12,21 @@ export function isEncryptionAction(action: EditorAction): boolean {
 }
 
 /**
+ * True when the text is a securebin ciphertext — the JSON blob produced by
+ * encrypt() — rather than prose that merely mentions the C_TXT marker.
+ */
+export function isCiphertext(text: string): boolean {
+  const trimmed = text.trim()
+  return trimmed.startsWith('{') && trimmed.includes(CIPHER_PREFIX)
+}
+
+/**
  * Infers the most appropriate action based on text content and the user's
  * configured default action.
  *
  * - C_TXT prefix → always DECRYPT
- * - pastebin.com URL → DECRYPT_PASTEBIN if default is an encryption action, else OPEN_PASTEBIN
+ * - pastebin.com URL → OPEN_PASTEBIN (opening auto-detects an encrypted paste
+ *   and hands off to the decrypt flow, so it covers both cases)
  * - plain text → returns defaultAction unchanged
  */
 export function detectAction(text: string, defaultAction: EditorAction): EditorAction {
@@ -30,7 +40,7 @@ export function detectAction(text: string, defaultAction: EditorAction): EditorA
   // substring of another hostname — neither "not-pastebin.com" (prefix) nor
   // "pastebin.com.evil.com" / "pastebin.community" (suffix) should match.
   if (/(?:^|[\s/:("'])pastebin\.com(?:[/\s:)"',]|$)/.test(trimmed)) {
-    return isEncryptionAction(defaultAction) ? EditorAction.DECRYPT_PASTEBIN : EditorAction.OPEN_PASTEBIN
+    return EditorAction.OPEN_PASTEBIN
   }
 
   return defaultAction
@@ -65,13 +75,11 @@ const LINK_ACTIONS = new Set<EditorAction>([
 const PASTEBIN_LINK_ONLY = /^(?:https?:\/\/)?(?:www\.)?pastebin\.com\/(?:raw\/)?\w+\/?$/i
 
 /** The whole trimmed text is a securebin ciphertext or a Pastebin paste link. */
-function detectContentAction(trimmed: string, defaultAction: EditorAction): EditorAction | null {
-  // Ciphertexts are the JSON blob produced by encrypt() — require the shape,
-  // not just the C_TXT marker somewhere in prose
-  if (trimmed.startsWith('{') && trimmed.includes(CIPHER_PREFIX)) return EditorAction.DECRYPT
-  if (PASTEBIN_LINK_ONLY.test(trimmed)) {
-    return isEncryptionAction(defaultAction) ? EditorAction.DECRYPT_PASTEBIN : EditorAction.OPEN_PASTEBIN
-  }
+function detectContentAction(trimmed: string): EditorAction | null {
+  if (isCiphertext(trimmed)) return EditorAction.DECRYPT
+  // Open Paste covers encrypted pastes too — opening auto-detects a
+  // ciphertext and hands off to the decrypt flow
+  if (PASTEBIN_LINK_ONLY.test(trimmed)) return EditorAction.OPEN_PASTEBIN
   return null
 }
 
@@ -80,7 +88,7 @@ export function detectActionOnChange(
   currentAction: EditorAction,
   defaultAction: EditorAction,
 ): EditorAction | undefined {
-  const detected = detectContentAction(text.trim(), defaultAction)
+  const detected = detectContentAction(text.trim())
   if (detected !== null) {
     if (detected === currentAction) return undefined
     if (LINK_ACTIONS.has(detected) && LINK_ACTIONS.has(currentAction)) return undefined

--- a/src/lib/editor-utils.ts
+++ b/src/lib/editor-utils.ts
@@ -36,6 +36,62 @@ export function detectAction(text: string, defaultAction: EditorAction): EditorA
   return defaultAction
 }
 
+// Actions that detectAction derives from the text itself rather than from the
+// user's default — the only ones auto-switching may enter or leave.
+const CONTENT_DETECTED_ACTIONS = new Set<EditorAction>([
+  EditorAction.DECRYPT,
+  EditorAction.DECRYPT_PASTEBIN,
+  EditorAction.OPEN_PASTEBIN,
+])
+
+/**
+ * Action to switch to as the user types or pastes, or undefined to keep the
+ * current one. Auto-switches only into a content-derived action (ciphertext or
+ * Pastebin link detected) or back out of one once the content no longer
+ * matches — an explicit choice like "Encrypt Only" is never overridden while
+ * the text stays plain.
+ */
+// Both are triggered by a Pastebin link — an explicit pick of one must not be
+// overridden by re-detection of the other while the text is still a link.
+const LINK_ACTIONS = new Set<EditorAction>([
+  EditorAction.DECRYPT_PASTEBIN,
+  EditorAction.OPEN_PASTEBIN,
+])
+
+// On-change detection runs on every keystroke, so it must be much stricter
+// than detectAction (which classifies a context-menu selection once): the
+// whole text has to BE a paste link — not merely mention pastebin.com in a
+// sentence — before we take the action button away from the user.
+const PASTEBIN_LINK_ONLY = /^(?:https?:\/\/)?(?:www\.)?pastebin\.com\/(?:raw\/)?\w+\/?$/i
+
+/** The whole trimmed text is a securebin ciphertext or a Pastebin paste link. */
+function detectContentAction(trimmed: string, defaultAction: EditorAction): EditorAction | null {
+  // Ciphertexts are the JSON blob produced by encrypt() — require the shape,
+  // not just the C_TXT marker somewhere in prose
+  if (trimmed.startsWith('{') && trimmed.includes(CIPHER_PREFIX)) return EditorAction.DECRYPT
+  if (PASTEBIN_LINK_ONLY.test(trimmed)) {
+    return isEncryptionAction(defaultAction) ? EditorAction.DECRYPT_PASTEBIN : EditorAction.OPEN_PASTEBIN
+  }
+  return null
+}
+
+export function detectActionOnChange(
+  text: string,
+  currentAction: EditorAction,
+  defaultAction: EditorAction,
+): EditorAction | undefined {
+  const detected = detectContentAction(text.trim(), defaultAction)
+  if (detected !== null) {
+    if (detected === currentAction) return undefined
+    if (LINK_ACTIONS.has(detected) && LINK_ACTIONS.has(currentAction)) return undefined
+    return detected
+  }
+  // Content no longer matches — leave a content-derived action, but never
+  // touch an explicit choice like "Encrypt Only" over plain text
+  if (CONTENT_DETECTED_ACTIONS.has(currentAction)) return defaultAction
+  return undefined
+}
+
 /**
  * Returns the maximum allowed plaintext character count for a given action.
  * For actions that post to Pastebin the limit reflects the 512 KB API maximum,

--- a/src/lib/panel-bus.ts
+++ b/src/lib/panel-bus.ts
@@ -1,0 +1,14 @@
+// In-process event bus for panel ↔ app signaling.
+//
+// Deliberately NOT window CustomEvents: the injected panel shares window and
+// DOM with the host page, so page scripts could forge our signals (e.g. a
+// fake "app-ready" that defeats the message buffer) or eavesdrop on payloads
+// (e.g. the paste URL in a quick-post result). This module instance lives in
+// the extension's own JS context — the popup page, or the content script's
+// isolated world, where App is part of the same bundle — which page scripts
+// cannot reach.
+export const panelBus = new EventTarget()
+
+export function emitPanelEvent(name: string, detail?: unknown): void {
+  panelBus.dispatchEvent(new CustomEvent(name, detail === undefined ? undefined : { detail }))
+}

--- a/src/lib/pastebin-detection.test.ts
+++ b/src/lib/pastebin-detection.test.ts
@@ -39,11 +39,11 @@ describe('Pastebin link detection via detectAction', () => {
     })
   })
 
-  describe('ENCRYPT_PASTEBIN default → DECRYPT_PASTEBIN for Pastebin URLs', () => {
+  describe('ENCRYPT_PASTEBIN default → OPEN_PASTEBIN for Pastebin URLs (open hands off to decrypt)', () => {
     const def = EditorAction.ENCRYPT_PASTEBIN
     pastebinUrls.forEach((url) => {
-      it(`detects DECRYPT_PASTEBIN for: "${url.trim()}"`, () => {
-        expect(detectAction(url, def)).toBe(EditorAction.DECRYPT_PASTEBIN)
+      it(`detects OPEN_PASTEBIN for: "${url.trim()}"`, () => {
+        expect(detectAction(url, def)).toBe(EditorAction.OPEN_PASTEBIN)
       })
     })
   })
@@ -113,10 +113,12 @@ describe('Open in SecureBin — initial action inference', () => {
 })
 
 // ---------------------------------------------------------------------------
-// isEncryptionAction drives Pastebin link routing
+// Pastebin links always route to OPEN_PASTEBIN — opening auto-detects an
+// encrypted paste and hands off to the decrypt flow, so the user's default
+// action no longer changes how a link is handled
 // ---------------------------------------------------------------------------
 
-describe('isEncryptionAction drives DECRYPT_PASTEBIN vs OPEN_PASTEBIN', () => {
+describe('Pastebin links route to OPEN_PASTEBIN regardless of default action', () => {
   const url = 'pastebin.com/abc123'
 
   it('POST default → OPEN_PASTEBIN for Pastebin links', () => {
@@ -124,13 +126,13 @@ describe('isEncryptionAction drives DECRYPT_PASTEBIN vs OPEN_PASTEBIN', () => {
     expect(detectAction(url, EditorAction.POST_PASTEBIN)).toBe(EditorAction.OPEN_PASTEBIN)
   })
 
-  it('ENCRYPT default → DECRYPT_PASTEBIN for Pastebin links', () => {
+  it('ENCRYPT default → OPEN_PASTEBIN for Pastebin links', () => {
     expect(isEncryptionAction(EditorAction.ENCRYPT)).toBe(true)
-    expect(detectAction(url, EditorAction.ENCRYPT)).toBe(EditorAction.DECRYPT_PASTEBIN)
+    expect(detectAction(url, EditorAction.ENCRYPT)).toBe(EditorAction.OPEN_PASTEBIN)
   })
 
-  it('ENCRYPT_PASTEBIN default → DECRYPT_PASTEBIN for Pastebin links', () => {
+  it('ENCRYPT_PASTEBIN default → OPEN_PASTEBIN for Pastebin links', () => {
     expect(isEncryptionAction(EditorAction.ENCRYPT_PASTEBIN)).toBe(true)
-    expect(detectAction(url, EditorAction.ENCRYPT_PASTEBIN)).toBe(EditorAction.DECRYPT_PASTEBIN)
+    expect(detectAction(url, EditorAction.ENCRYPT_PASTEBIN)).toBe(EditorAction.OPEN_PASTEBIN)
   })
 })

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -81,6 +81,11 @@ interface AppState {
   clearHistory: () => void
   loadHistory: () => Promise<void>
 
+  // Decrypt result — in-memory only. Decrypted plaintext is deliberately never
+  // written to extension storage (history stores ciphertext, not plaintext).
+  decryptResult: { plaintext: string; date: number } | null
+  setDecryptResult: (result: { plaintext: string; date: number } | null) => void
+
   // Dialog
   activeDialog: string | null
   openDialog: (id: string) => void
@@ -288,6 +293,10 @@ export const useStore = create<AppState>((set, get) => ({
       set({ history: items.reverse() })
     }
   },
+
+  // Decrypt result
+  decryptResult: null,
+  setDecryptResult: (result) => set({ decryptResult: result }),
 
   // Dialog
   activeDialog: null,

--- a/src/routes/DecryptResult.tsx
+++ b/src/routes/DecryptResult.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { format } from 'date-fns'
+import { Copy, Check, Unlock, Pencil } from 'lucide-react'
+import { useStore, resolveTheme } from '@/lib/store'
+import { detectLanguage } from '@/lib/detect-language'
+import { detectAction } from '@/lib/editor-utils'
+import PageHeader from '@/components/common/PageHeader'
+import CodePreview from '@/components/common/CodePreview'
+import { cn } from '@/lib/cn'
+
+const CODE_BG_LIGHT = '#f3f3f5'
+const CODE_BG_DARK = '#2c313c'
+
+export default function DecryptResult() {
+  const navigate = useNavigate()
+  const { decryptResult, settings, updateDraft } = useStore()
+  const isDark = resolveTheme(settings.theme) === 'dark'
+  const [copied, setCopied] = useState(false)
+
+  if (!decryptResult) {
+    return (
+      <>
+        <PageHeader title="Decrypted" />
+        <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+          <p className="text-sm text-text-muted">Nothing to display.</p>
+        </div>
+      </>
+    )
+  }
+
+  const { plaintext, date } = decryptResult
+  const contentFormat = plaintext.length > 80 ? detectLanguage(plaintext) : 'text'
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(plaintext)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const handleOpenInEditor = () => {
+    updateDraft({
+      plaintext,
+      format: contentFormat,
+      formatLocked: false,
+      action: detectAction(plaintext, settings.default_action),
+    })
+    navigate('/home')
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <PageHeader title="Decrypted" subtitle={format(new Date(date), 'h:mm a, MMMM d, yyyy')} />
+
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+        {/* Success banner */}
+        <div className="flex items-center gap-2.5 rounded-xl border border-success/20 bg-success/5 px-4 py-3">
+          <Unlock size={15} className="text-success shrink-0" />
+          <p className="text-sm text-success font-medium leading-snug">Decrypted successfully</p>
+        </div>
+
+        {/* Decrypted content */}
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <label className="text-xs font-medium text-text-secondary">Content</label>
+            <button
+              onClick={handleCopy}
+              className={cn(
+                'flex items-center gap-1 text-xs transition-colors',
+                copied ? 'text-success' : 'text-text-muted hover:text-text-secondary',
+              )}
+            >
+              {copied ? <Check size={12} /> : <Copy size={12} />}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+          <div
+            className="rounded-xl border border-border overflow-hidden"
+            style={{ backgroundColor: isDark ? CODE_BG_DARK : CODE_BG_LIGHT }}
+          >
+            <CodePreview
+              code={plaintext}
+              format={contentFormat}
+              isDark={isDark}
+              maxHeight="280px"
+              showGutter
+            />
+          </div>
+          <p className="text-[11px] text-text-muted/70 leading-snug">
+            Shown only here — decrypted content is never saved to history.
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="pt-2 space-y-2">
+          <button
+            onClick={handleCopy}
+            className={cn(
+              'w-full flex items-center justify-center gap-2 py-3 rounded-xl text-sm font-semibold transition-all',
+              copied
+                ? 'border border-success/30 bg-success/5 text-success'
+                : 'bg-primary text-white hover:bg-primary-hover active:scale-[0.98]',
+            )}
+          >
+            {copied ? <Check size={15} /> : <Copy size={15} />}
+            {copied ? 'Copied!' : 'Copy Content'}
+          </button>
+          <button
+            onClick={handleOpenInEditor}
+            className="w-full flex items-center justify-center gap-2 py-3 rounded-xl border border-border text-sm font-semibold text-text-secondary hover:bg-surface-hover transition-colors"
+          >
+            <Pencil size={15} />
+            Open in Editor
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/Editor.tsx
+++ b/src/routes/Editor.tsx
@@ -4,7 +4,7 @@ import { useStore } from '@/lib/store'
 import { encrypt, decrypt as decryptText } from '@/lib/crypto'
 import { postPastebin, getPastebin } from '@/lib/pastebin'
 import { EditorAction } from '@/lib/constants'
-import { detectAction } from '@/lib/editor-utils'
+import { detectAction, isCiphertext } from '@/lib/editor-utils'
 import { panelBus } from '@/lib/panel-bus'
 import TextEditor from '@/components/editor/TextEditor'
 import ActionBar from '@/components/editor/ActionBar'
@@ -158,10 +158,17 @@ export default function Editor() {
           navigate('/decrypted')
         } else if (action === EditorAction.OPEN_PASTEBIN) {
           const pasteText = await getPastebin(plaintext)
-          updateDraft({
-            plaintext: pasteText,
-            action: detectAction(pasteText, settings.default_action),
-          })
+          if (isCiphertext(pasteText)) {
+            // Encrypted paste — load the ciphertext and go straight to the
+            // passkey prompt; confirming lands on the decrypted view
+            updateDraft({ plaintext: pasteText, action: EditorAction.DECRYPT })
+            setDecDialogOpen(true)
+          } else {
+            updateDraft({
+              plaintext: pasteText,
+              action: detectAction(pasteText, settings.default_action),
+            })
+          }
         }
       } catch (err) {
         addToHistory({

--- a/src/routes/Editor.tsx
+++ b/src/routes/Editor.tsx
@@ -5,6 +5,7 @@ import { encrypt, decrypt as decryptText } from '@/lib/crypto'
 import { postPastebin, getPastebin } from '@/lib/pastebin'
 import { EditorAction } from '@/lib/constants'
 import { detectAction } from '@/lib/editor-utils'
+import { panelBus } from '@/lib/panel-bus'
 import TextEditor from '@/components/editor/TextEditor'
 import ActionBar from '@/components/editor/ActionBar'
 import PasteMetadata from '@/components/editor/PasteMetadata'
@@ -13,7 +14,7 @@ import DecryptDialog from '@/components/dialog/DecryptDialog'
 
 export default function Editor() {
   const navigate = useNavigate()
-  const { draft, settings, updateDraft, resetDraft, addToHistory } = useStore()
+  const { draft, settings, updateDraft, resetDraft, addToHistory, setDecryptResult } = useStore()
   const [encDialogOpen, setEncDialogOpen] = useState(false)
   const [decDialogOpen, setDecDialogOpen] = useState(false)
   const [loading, setLoading] = useState(false)
@@ -29,8 +30,8 @@ export default function Editor() {
         action: EditorAction.DECRYPT,
       })
     }
-    window.addEventListener('securebin:load-for-decrypt', handler)
-    return () => window.removeEventListener('securebin:load-for-decrypt', handler)
+    panelBus.addEventListener('securebin:load-for-decrypt', handler)
+    return () => panelBus.removeEventListener('securebin:load-for-decrypt', handler)
   }, [updateDraft])
 
 
@@ -146,17 +147,15 @@ export default function Editor() {
           navigate('/result')
         } else if (action === EditorAction.DECRYPT && passkey) {
           const decrypted = await decryptText(plaintext, passkey)
-          updateDraft({
-            plaintext: decrypted,
-            action: detectAction(decrypted, settings.default_action),
-          })
+          // Show the plaintext on its own page; the ciphertext stays in the
+          // editor so nothing is lost if the user navigates back.
+          setDecryptResult({ plaintext: decrypted, date: Date.now() })
+          navigate('/decrypted')
         } else if (action === EditorAction.DECRYPT_PASTEBIN && passkey) {
           const pasteText = await getPastebin(plaintext)
           const decrypted = await decryptText(pasteText, passkey)
-          updateDraft({
-            plaintext: decrypted,
-            action: detectAction(decrypted, settings.default_action),
-          })
+          setDecryptResult({ plaintext: decrypted, date: Date.now() })
+          navigate('/decrypted')
         } else if (action === EditorAction.OPEN_PASTEBIN) {
           const pasteText = await getPastebin(plaintext)
           updateDraft({
@@ -181,7 +180,7 @@ export default function Editor() {
         setLoading(false)
       }
     },
-    [draft, settings, addToHistory, resetDraft, updateDraft, navigate],
+    [draft, settings, addToHistory, resetDraft, updateDraft, setDecryptResult, navigate],
   )
 
   return (

--- a/src/routes/Result.tsx
+++ b/src/routes/Result.tsx
@@ -5,6 +5,7 @@ import { Copy, Check, Loader2, LogIn, Globe, EyeOff, Lock, Clock, Pencil, Send, 
 import { useStore, resolveTheme } from '@/lib/store'
 import { EditorAction, hasCustomApiKey } from '@/lib/constants'
 import { deletePastebin, extractPasteKey } from '@/lib/pastebin'
+import { emitPanelEvent } from '@/lib/panel-bus'
 import PageHeader from '@/components/common/PageHeader'
 import CopyBox from '@/components/common/CopyBox'
 import CodePreview from '@/components/common/CodePreview'
@@ -87,7 +88,7 @@ export default function Result() {
 
   const handleDecrypt = () => {
     const ciphertext = item.encText ?? ''
-    window.dispatchEvent(new CustomEvent('securebin:load-for-decrypt', { detail: { ciphertext } }))
+    emitPanelEvent('securebin:load-for-decrypt', { ciphertext })
     navigate('/home')
   }
 


### PR DESCRIPTION
Fixes the two bugs reported after the 2.0.3 submission, plus the paste-link flow and hardening found in review.

## Bugs fixed

**1. Quick-post loading looked broken (right-click → Post to Pastebin)**
With 2.0.3's on-demand injection, the background's `SB_OPEN {quickPostLoading}` / `{pendingText}` messages arrive before React mounts the panel's event listeners, so the branded loading screen (and context-menu text) were silently dropped — you saw the bare init spinner and a stale editor instead. The content script now buffers app-bound events until the app signals readiness.

**2. Decryption was unreachable**
Pasting a ciphertext never flipped the action button to Decrypt (the editor's change handler never ran detection), and with the default settings the dropdown had no Decrypt entry at all. Both restored. On-change detection is deliberately strict: the whole text must *be* a ciphertext blob or a paste link — mentioning `pastebin.com` mid-sentence never hijacks an explicitly chosen action.

## New: paste-link flow

Pasting a pastebin.com link defaults the button to **Open Paste**. Opening fetches the paste and auto-detects encryption: a securebin ciphertext hands off straight to the passkey prompt and lands on the decrypted view; a plain paste loads into the editor. "Decrypt from Link" stays in the dropdown for the explicit passkey-first flow.

## New: decrypted-content view

Decrypting lands on a dedicated `/decrypted` page (success banner, syntax-highlighted content, Copy Content, Open in Editor) instead of silently replacing the editor text. The plaintext is held in memory only — never written to history — and is dropped when the panel closes.

## Hardening (from adversarial review)

- All panel ↔ app signaling moved off `window` CustomEvents onto a module-scoped bus (`src/lib/panel-bus.ts`). The injected panel shares `window` with the host page, so page scripts could previously forge signals (e.g. a fake `app-ready` that defeats the buffering) or eavesdrop on quick-post results (paste URL).
- ActionBar menu divider restored between compose and decrypt groups.

## Verification

- 84-test vitest suite (incl. live Pastebin e2e), 20 new unit tests for `detectActionOnChange` / `isCiphertext`
- 9/9 `npm run test:relay` (unchanged)
- New `npm run test:ui` live harness (`scripts/verify-ui.mjs`, puppeteer + Chrome for Testing): 22/22 — fresh-injection quick-post loading + result, context-menu text, ciphertext → Decrypt flip, passkey dialog, decrypted view, close-drops-plaintext, re-decrypt, open-in-editor round-trip, and real posted-paste link flows (encrypted → auto-decrypt, plain → editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)