### PR TITLE
Fix Decrypt from history, remove dead share link, strict detection everywhere

### DIFF
--- a/scripts/verify-ui.mjs
+++ b/scripts/verify-ui.mjs
@@ -328,7 +328,66 @@ try {
   await shot(page2, '6-open-in-editor-roundtrip')
   check('Open in Editor loads the plaintext back into the editor', roundTripped)
 
-  // ── 4. Paste link → Open Paste → auto-decrypt handoff (needs API key) ─────
+  // ── 4. Encrypt Only → history result → Decrypt → decrypted view ───────────
+  // Covers the Result-page Decrypt button, which must load the ciphertext AND
+  // open the passkey prompt (it used to fire an event before the editor
+  // mounted, dropping the request entirely).
+  const histPass = 'history-verify-pass'
+  await page2.evaluate(() => {
+    // Open the action dropdown (rounded-right half of the split button)
+    window.__sb.buttons().find(b => b.className.includes('rounded-r-full'))?.click()
+  })
+  const encryptOnly = await page2.evaluate(async () => {
+    const start = Date.now()
+    while (Date.now() - start < 4000) {
+      if (window.__sb.clickButton('Encrypt Only')) return true
+      await new Promise(r => setTimeout(r, 100))
+    }
+    return false
+  })
+  check('Encrypt Only picked from the dropdown', encryptOnly)
+
+  const encDialog = await page2.evaluate(() => window.__sb.waitForText('Encryption Passkey'))
+  check('encryption passkey dialog opens', encDialog)
+  await page2.evaluate(k => window.__sb.setInput('passkey', k), histPass)
+  await page2.evaluate(() => {
+    const buttons = window.__sb.buttons().filter(b => b.textContent.trim() === 'Encrypt')
+    buttons[buttons.length - 1]?.click()
+  })
+  const onResult = await page2.evaluate(() => window.__sb.waitForText('Ciphertext'))
+  check('encryption lands on the result page', onResult)
+
+  const shareLinkGone = await page2.evaluate(() => !window.__sb.text().includes('Copy Share Link'))
+  check('Copy Share Link button is removed', shareLinkGone)
+
+  await page2.evaluate(() => window.__sb.clickButton('Decrypt'))
+  const resultDecryptDialog = await page2.evaluate(() => window.__sb.waitForText('Decryption Key'))
+  await shot(page2, '6b-history-decrypt-dialog')
+  check('Decrypt on a history item opens the passkey prompt', resultDecryptDialog)
+
+  await page2.evaluate(k => window.__sb.setInput('decryption key', k), histPass)
+  await page2.evaluate(() => {
+    const buttons = window.__sb.buttons().filter(b => b.textContent.trim() === 'Decrypt')
+    buttons[buttons.length - 1]?.click()
+  })
+  const historyDecrypted = await page2.evaluate(async s => {
+    const ok = await window.__sb.waitForText('Decrypted successfully')
+    return ok && window.__sb.text().includes(s)
+  }, secret)
+  await shot(page2, '6c-history-decrypted')
+  check('history item decrypts to the decrypted view', historyDecrypted)
+
+  // Back to the editor for the sections below
+  await page2.evaluate(() => window.__sb.clickButton('Open in Editor'))
+  await page2.evaluate(async () => {
+    const start = Date.now()
+    while (Date.now() - start < 4000) {
+      if (window.__sb.root()?.querySelector('textarea')) return
+      await new Promise(r => setTimeout(r, 100))
+    }
+  })
+
+  // ── 5. Paste link → Open Paste → auto-decrypt handoff (needs API key) ─────
   if (API_KEY) {
     const postViaSW = (code) => sw.evaluate(async (apiKey, pasteCode) => {
       const body = new URLSearchParams({

--- a/src/lib/editor-utils.test.ts
+++ b/src/lib/editor-utils.test.ts
@@ -94,6 +94,7 @@ describe('getMaxLength', () => {
 
 describe('detectAction with POST_PASTEBIN default', () => {
   const def = EditorAction.POST_PASTEBIN
+  const cipher = '{"C_TXT":"abc","IV":"def","Mode":"AES-GCM","Tag":"ghi"}'
 
   it('returns default for plain text', () => {
     expect(detectAction('hello world', def)).toBe(EditorAction.POST_PASTEBIN)
@@ -107,12 +108,26 @@ describe('detectAction with POST_PASTEBIN default', () => {
     expect(detectAction('pastebin.com/xyz', def)).toBe(EditorAction.OPEN_PASTEBIN)
   })
 
-  it('detects DECRYPT for text containing the cipher prefix', () => {
-    expect(detectAction('C_TXT:abc:def:ghi', def)).toBe(EditorAction.DECRYPT)
+  it('detects DECRYPT for a ciphertext blob', () => {
+    expect(detectAction(cipher, def)).toBe(EditorAction.DECRYPT)
   })
 
-  it('cipher prefix takes priority over pastebin URL', () => {
-    expect(detectAction('C_TXT pastebin.com/abc', def)).toBe(EditorAction.DECRYPT)
+  it('ciphertext takes priority over a pastebin URL inside it', () => {
+    expect(detectAction('{"C_TXT":"abc","src":"pastebin.com/abc"}', def)).toBe(EditorAction.DECRYPT)
+  })
+
+  it('does NOT match prose that merely mentions pastebin.com', () => {
+    // The exact failure the user hit: selected release notes mentioning the
+    // domain flipped the action to Open Paste
+    expect(detectAction('just mentioning pastebin.com in a note never changes your selected action', def)).toBe(EditorAction.POST_PASTEBIN)
+  })
+
+  it('does NOT match prose with an embedded pastebin link', () => {
+    expect(detectAction('Check this out: pastebin.com/abc123 for more', def)).toBe(EditorAction.POST_PASTEBIN)
+  })
+
+  it('does NOT match prose mentioning C_TXT', () => {
+    expect(detectAction('the C_TXT field holds the ciphertext', def)).toBe(EditorAction.POST_PASTEBIN)
   })
 
   it('does NOT match not-pastebin.com', () => {
@@ -127,8 +142,8 @@ describe('detectAction with POST_PASTEBIN default', () => {
     expect(detectAction('https://pastebin.community/fake', def)).toBe(EditorAction.POST_PASTEBIN)
   })
 
-  it('matches a bare pastebin.com domain with no path', () => {
-    expect(detectAction('pastebin.com', def)).toBe(EditorAction.OPEN_PASTEBIN)
+  it('does NOT match the bare domain with no paste id', () => {
+    expect(detectAction('pastebin.com', def)).toBe(EditorAction.POST_PASTEBIN)
   })
 })
 
@@ -147,8 +162,8 @@ describe('detectAction with ENCRYPT_PASTEBIN default', () => {
     expect(detectAction('https://pastebin.com/abc123', def)).toBe(EditorAction.OPEN_PASTEBIN)
   })
 
-  it('detects DECRYPT for cipher prefix regardless of default', () => {
-    expect(detectAction('C_TXT:abc:def:ghi', def)).toBe(EditorAction.DECRYPT)
+  it('detects DECRYPT for a ciphertext blob regardless of default', () => {
+    expect(detectAction('{"C_TXT":"abc","IV":"def","Mode":"AES-GCM","Tag":"ghi"}', def)).toBe(EditorAction.DECRYPT)
   })
 })
 

--- a/src/lib/editor-utils.ts
+++ b/src/lib/editor-utils.ts
@@ -20,36 +20,46 @@ export function isCiphertext(text: string): boolean {
   return trimmed.startsWith('{') && trimmed.includes(CIPHER_PREFIX)
 }
 
+// The whole text has to BE a paste link — pastebin.com/<id>, optionally
+// scheme/www/raw — not merely mention the domain somewhere in a sentence.
+const PASTEBIN_LINK_ONLY = /^(?:https?:\/\/)?(?:www\.)?pastebin\.com\/(?:raw\/)?\w+\/?$/i
+
 /**
- * Infers the most appropriate action based on text content and the user's
- * configured default action.
+ * The whole trimmed text is a securebin ciphertext or a Pastebin paste link,
+ * or null for anything else. This is deliberately strict — prose that merely
+ * mentions pastebin.com or C_TXT must never change the user's action.
+ */
+function detectContentAction(trimmed: string): EditorAction | null {
+  if (isCiphertext(trimmed)) return EditorAction.DECRYPT
+  // Open Paste covers encrypted pastes too — opening auto-detects a
+  // ciphertext and hands off to the decrypt flow
+  if (PASTEBIN_LINK_ONLY.test(trimmed)) return EditorAction.OPEN_PASTEBIN
+  return null
+}
+
+/**
+ * Infers the most appropriate action for a piece of text.
  *
- * - C_TXT prefix → always DECRYPT
- * - pastebin.com URL → OPEN_PASTEBIN (opening auto-detects an encrypted paste
- *   and hands off to the decrypt flow, so it covers both cases)
- * - plain text → returns defaultAction unchanged
+ * - securebin ciphertext blob → DECRYPT
+ * - a pastebin.com paste link → OPEN_PASTEBIN (opening auto-detects an
+ *   encrypted paste and hands off to the decrypt flow, so it covers both)
+ * - anything else → defaultAction unchanged
  */
 export function detectAction(text: string, defaultAction: EditorAction): EditorAction {
-  const trimmed = text.trim()
-
-  if (trimmed.includes(CIPHER_PREFIX)) {
-    return EditorAction.DECRYPT
-  }
-
-  // Match pastebin.com only when it appears as a whole domain, not as a
-  // substring of another hostname — neither "not-pastebin.com" (prefix) nor
-  // "pastebin.com.evil.com" / "pastebin.community" (suffix) should match.
-  if (/(?:^|[\s/:("'])pastebin\.com(?:[/\s:)"',]|$)/.test(trimmed)) {
-    return EditorAction.OPEN_PASTEBIN
-  }
-
-  return defaultAction
+  return detectContentAction(text.trim()) ?? defaultAction
 }
 
 // Actions that detectAction derives from the text itself rather than from the
 // user's default — the only ones auto-switching may enter or leave.
 const CONTENT_DETECTED_ACTIONS = new Set<EditorAction>([
   EditorAction.DECRYPT,
+  EditorAction.DECRYPT_PASTEBIN,
+  EditorAction.OPEN_PASTEBIN,
+])
+
+// Both are triggered by a Pastebin link — an explicit pick of one must not be
+// overridden by re-detection of the other while the text is still a link.
+const LINK_ACTIONS = new Set<EditorAction>([
   EditorAction.DECRYPT_PASTEBIN,
   EditorAction.OPEN_PASTEBIN,
 ])
@@ -61,28 +71,6 @@ const CONTENT_DETECTED_ACTIONS = new Set<EditorAction>([
  * matches — an explicit choice like "Encrypt Only" is never overridden while
  * the text stays plain.
  */
-// Both are triggered by a Pastebin link — an explicit pick of one must not be
-// overridden by re-detection of the other while the text is still a link.
-const LINK_ACTIONS = new Set<EditorAction>([
-  EditorAction.DECRYPT_PASTEBIN,
-  EditorAction.OPEN_PASTEBIN,
-])
-
-// On-change detection runs on every keystroke, so it must be much stricter
-// than detectAction (which classifies a context-menu selection once): the
-// whole text has to BE a paste link — not merely mention pastebin.com in a
-// sentence — before we take the action button away from the user.
-const PASTEBIN_LINK_ONLY = /^(?:https?:\/\/)?(?:www\.)?pastebin\.com\/(?:raw\/)?\w+\/?$/i
-
-/** The whole trimmed text is a securebin ciphertext or a Pastebin paste link. */
-function detectContentAction(trimmed: string): EditorAction | null {
-  if (isCiphertext(trimmed)) return EditorAction.DECRYPT
-  // Open Paste covers encrypted pastes too — opening auto-detects a
-  // ciphertext and hands off to the decrypt flow
-  if (PASTEBIN_LINK_ONLY.test(trimmed)) return EditorAction.OPEN_PASTEBIN
-  return null
-}
-
 export function detectActionOnChange(
   text: string,
   currentAction: EditorAction,

--- a/src/lib/pastebin-detection.test.ts
+++ b/src/lib/pastebin-detection.test.ts
@@ -12,7 +12,7 @@ describe('Pastebin link detection via detectAction', () => {
     'http://pastebin.com/xyz',
     'pastebin.com/AbCdEf',
     '  pastebin.com/raw/abc  ',
-    'Check this out: pastebin.com/abc123 for more',
+    'https://www.pastebin.com/abc123',
   ]
 
   const nonPastebinTexts = [
@@ -20,6 +20,10 @@ describe('Pastebin link detection via detectAction', () => {
     'just some plain text',
     'not-pastebin.com/fake',
     'https://github.com/user/repo',
+    // The whole text must BE a link — prose around it must not trigger
+    'Check this out: pastebin.com/abc123 for more',
+    'just mentioning pastebin.com in a note',
+    'pastebin.com',
   ]
 
   describe('POST_PASTEBIN default → OPEN_PASTEBIN for Pastebin URLs', () => {
@@ -48,12 +52,12 @@ describe('Pastebin link detection via detectAction', () => {
     })
   })
 
-  it('cipher prefix takes priority over Pastebin URL (POST default)', () => {
-    expect(detectAction(`${CIPHER_PREFIX} pastebin.com/abc`, EditorAction.POST_PASTEBIN)).toBe(EditorAction.DECRYPT)
+  it('ciphertext blob takes priority over an embedded Pastebin URL (POST default)', () => {
+    expect(detectAction(`{"${CIPHER_PREFIX}":"abc","src":"pastebin.com/abc"}`, EditorAction.POST_PASTEBIN)).toBe(EditorAction.DECRYPT)
   })
 
-  it('cipher prefix takes priority over Pastebin URL (ENCRYPT default)', () => {
-    expect(detectAction(`${CIPHER_PREFIX} pastebin.com/abc`, EditorAction.ENCRYPT_PASTEBIN)).toBe(EditorAction.DECRYPT)
+  it('ciphertext blob takes priority over an embedded Pastebin URL (ENCRYPT default)', () => {
+    expect(detectAction(`{"${CIPHER_PREFIX}":"abc","src":"pastebin.com/abc"}`, EditorAction.ENCRYPT_PASTEBIN)).toBe(EditorAction.DECRYPT)
   })
 })
 
@@ -91,24 +95,26 @@ describe('isPastebinLink (ActionBar conditional visibility)', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Open in SecureBin — initial action inference
+// "Open in Editor" (context menu) — initial action inference via detectAction
 // ---------------------------------------------------------------------------
 
-describe('Open in SecureBin — initial action inference', () => {
-  function inferInitialAction(text: string): EditorAction {
-    return text.trim().includes(CIPHER_PREFIX) ? EditorAction.DECRYPT : EditorAction.POST_PASTEBIN
-  }
+describe('Open in Editor — initial action inference', () => {
+  const def = EditorAction.POST_PASTEBIN
 
-  it('routes cipher text to DECRYPT', () => {
-    expect(inferInitialAction('C_TXT:iv:salt:ciphertext')).toBe(EditorAction.DECRYPT)
+  it('routes a ciphertext blob to DECRYPT', () => {
+    expect(detectAction(`{"${CIPHER_PREFIX}":"iv","IV":"x"}`, def)).toBe(EditorAction.DECRYPT)
   })
 
-  it('routes plain text to POST_PASTEBIN', () => {
-    expect(inferInitialAction('just some selected text')).toBe(EditorAction.POST_PASTEBIN)
+  it('routes plain text to the default action', () => {
+    expect(detectAction('just some selected text', def)).toBe(EditorAction.POST_PASTEBIN)
   })
 
-  it('handles whitespace-padded cipher text', () => {
-    expect(inferInitialAction('   C_TXT:data   ')).toBe(EditorAction.DECRYPT)
+  it('handles whitespace-padded ciphertext', () => {
+    expect(detectAction(`   {"${CIPHER_PREFIX}":"data"}   `, def)).toBe(EditorAction.DECRYPT)
+  })
+
+  it('routes prose mentioning C_TXT to the default action', () => {
+    expect(detectAction('C_TXT:iv:salt:ciphertext is the legacy shape', def)).toBe(EditorAction.POST_PASTEBIN)
   })
 })
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -86,6 +86,13 @@ interface AppState {
   decryptResult: { plaintext: string; date: number } | null
   setDecryptResult: (result: { plaintext: string; date: number } | null) => void
 
+  // Ciphertext queued for decryption (e.g. Decrypt on a history item) —
+  // Editor consumes it on mount and opens the passkey prompt. A store field,
+  // not an event: the requester navigates to the editor, which isn't mounted
+  // yet when the request is made.
+  decryptRequest: string | null
+  setDecryptRequest: (ciphertext: string | null) => void
+
   // Dialog
   activeDialog: string | null
   openDialog: (id: string) => void
@@ -297,6 +304,10 @@ export const useStore = create<AppState>((set, get) => ({
   // Decrypt result
   decryptResult: null,
   setDecryptResult: (result) => set({ decryptResult: result }),
+
+  // Decrypt request
+  decryptRequest: null,
+  setDecryptRequest: (ciphertext) => set({ decryptRequest: ciphertext }),
 
   // Dialog
   activeDialog: null,

--- a/src/routes/Editor.tsx
+++ b/src/routes/Editor.tsx
@@ -5,7 +5,6 @@ import { encrypt, decrypt as decryptText } from '@/lib/crypto'
 import { postPastebin, getPastebin } from '@/lib/pastebin'
 import { EditorAction } from '@/lib/constants'
 import { detectAction, isCiphertext } from '@/lib/editor-utils'
-import { panelBus } from '@/lib/panel-bus'
 import TextEditor from '@/components/editor/TextEditor'
 import ActionBar from '@/components/editor/ActionBar'
 import PasteMetadata from '@/components/editor/PasteMetadata'
@@ -14,25 +13,22 @@ import DecryptDialog from '@/components/dialog/DecryptDialog'
 
 export default function Editor() {
   const navigate = useNavigate()
-  const { draft, settings, updateDraft, resetDraft, addToHistory, setDecryptResult } = useStore()
+  const { draft, settings, updateDraft, resetDraft, addToHistory, setDecryptResult, decryptRequest, setDecryptRequest } = useStore()
   const [encDialogOpen, setEncDialogOpen] = useState(false)
   const [decDialogOpen, setDecDialogOpen] = useState(false)
   const [loading, setLoading] = useState(false)
 
   // Context-menu text ("Open in Editor") is handled centrally in App.tsx —
-  // via chrome.storage.session in popup mode and window events when injected.
+  // via chrome.storage.session in popup mode and panelBus events when injected.
 
+  // Decrypt requested from a history item / result page: load the ciphertext
+  // and go straight to the passkey prompt
   useEffect(() => {
-    const handler = (e: Event) => {
-      const { ciphertext } = (e as CustomEvent).detail
-      updateDraft({
-        plaintext: ciphertext,
-        action: EditorAction.DECRYPT,
-      })
-    }
-    panelBus.addEventListener('securebin:load-for-decrypt', handler)
-    return () => panelBus.removeEventListener('securebin:load-for-decrypt', handler)
-  }, [updateDraft])
+    if (!decryptRequest) return
+    updateDraft({ plaintext: decryptRequest, action: EditorAction.DECRYPT })
+    setDecryptRequest(null)
+    setDecDialogOpen(true)
+  }, [decryptRequest, updateDraft, setDecryptRequest])
 
 
   const handleAction = useCallback((overrideAction?: EditorAction) => {

--- a/src/routes/Result.tsx
+++ b/src/routes/Result.tsx
@@ -5,7 +5,6 @@ import { Copy, Check, Loader2, LogIn, Globe, EyeOff, Lock, Clock, Pencil, Send, 
 import { useStore, resolveTheme } from '@/lib/store'
 import { EditorAction, hasCustomApiKey } from '@/lib/constants'
 import { deletePastebin, extractPasteKey } from '@/lib/pastebin'
-import { emitPanelEvent } from '@/lib/panel-bus'
 import PageHeader from '@/components/common/PageHeader'
 import CopyBox from '@/components/common/CopyBox'
 import CodePreview from '@/components/common/CodePreview'
@@ -24,12 +23,11 @@ const CODE_BG_DARK = '#2c313c'
 export default function Result() {
   const { index } = useParams()
   const navigate = useNavigate()
-  const { history, removeFromHistory, settings, updateDraft } = useStore()
+  const { history, removeFromHistory, settings, updateDraft, setDecryptRequest } = useStore()
   const isDark = resolveTheme(settings.theme) === 'dark'
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState('')
-  const [shareCopied, setShareCopied] = useState(false)
   const [contentCopied, setContentCopied] = useState(false)
   const [postDropdownOpen, setPostDropdownOpen] = useState(false)
 
@@ -87,18 +85,9 @@ export default function Result() {
   }
 
   const handleDecrypt = () => {
-    const ciphertext = item.encText ?? ''
-    emitPanelEvent('securebin:load-for-decrypt', { ciphertext })
+    // Via the store, not an event — the editor isn't mounted yet
+    setDecryptRequest(item.encText ?? '')
     navigate('/home')
-  }
-
-  const handleCopyShareLink = async () => {
-    if (!hasPastebin || !item.key) return
-    const pasteKey = extractPasteKey(item.pastebinLink)
-    const shareLink = `https://securebin.org/view#key=${encodeURIComponent(item.key)}&paste=${pasteKey}`
-    await navigator.clipboard.writeText(shareLink)
-    setShareCopied(true)
-    setTimeout(() => setShareCopied(false), 2000)
   }
 
   // Load draft content into editor with the chosen action, then navigate to editor
@@ -212,22 +201,6 @@ export default function Result() {
 
         {/* Passkey */}
         {item.key && <CopyBox label="Passkey" value={item.key} masked />}
-
-        {/* Share link */}
-        {hasPastebin && item.key && (
-          <button
-            onClick={handleCopyShareLink}
-            className={cn(
-              'w-full flex items-center justify-center gap-2 py-2.5 rounded-xl border text-sm font-medium transition-all',
-              shareCopied
-                ? 'border-success/30 bg-success/5 text-success'
-                : 'border-border text-text-secondary hover:bg-surface-hover',
-            )}
-          >
-            {shareCopied ? <Check size={14} /> : <Copy size={14} />}
-            {shareCopied ? 'Share link copied!' : 'Copy Share Link'}
-          </button>
-        )}
 
         {/* Actions */}
         <div className="pt-2 space-y-2">


### PR DESCRIPTION
Fixes the three issues found while testing v2.0.4 locally.

**1. Decrypt from a history item did nothing** — it fired the load-for-decrypt event *before* navigating to the editor, but the editor wasn't mounted yet, so the request vanished and you landed on a stale editor. (This predates the panel-bus change — likely the original "decryption completely not working".) The request now travels through the store; the editor consumes it on mount and opens the passkey prompt immediately, landing on the decrypted view after confirmation.

**2. Copy Share Link removed** — it built a `https://securebin.org/view#…` URL, but that viewer page doesn't exist on the site.

**3. "Open Paste" on plain prose** — selecting text that merely *mentions* pastebin.com (e.g. the v2.0.4 release notes) and using right-click → Open in Editor set the action to Open Paste. `detectAction` now uses the same strict whole-text classifier as typing/pasting: the text must *be* a paste link or ciphertext blob.

## Verification
- 85/85 detection unit tests (new cases: prose mentions, embedded links, bare domain)
- `npm run test:ui` 22/22 offline checks, now including: Encrypt Only → result page → Decrypt → auto passkey prompt → decrypted view; Copy Share Link absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)